### PR TITLE
Fix amount issue

### DIFF
--- a/packages/service-manager/utils/cosmos.ts
+++ b/packages/service-manager/utils/cosmos.ts
@@ -61,7 +61,7 @@ function getAmountString(obJ: object) : string {
     denom = obJ[0]["denom"].substring(1)
     amount = (Number(obJ[0]["amount"]) / 1000000).toString()
   } else {
-    denom = obJ[0]["denom"].substring(1)
+    denom = obJ[0]["denom"]
     amount = obJ[0]["amount"]
   }
   return amount + " " + denom

--- a/packages/service-manager/utils/cosmos.ts
+++ b/packages/service-manager/utils/cosmos.ts
@@ -35,17 +35,31 @@ function convertToName(typeUrl: string): string {
 function convertToKeyValue(obj: { [key: string]: any }): { [key: string]: string } {
   const KV: { [key: string]: string } = {};
   Object.entries(obj).forEach((entry) => {
-    if (typeof entry[1] === "object") {
 
-      // Flatten nested objects into top level keys
-      Object.entries(entry[1]).forEach((subentry) => {
-        KV[`${fixCapsAndSpacing(entry[0])} ${fixCapsAndSpacing(subentry[0])}`] = String(subentry[1]);
-      });
+    if (typeof entry[1] === "object") {
+      if(entry[0] == "amount") {
+        KV[fixCapsAndSpacing(entry[0])] = getAmountString(entry[1])
+      } else {
+        // Flatten nested objects into top level keys
+        Object.entries(entry[1]).forEach((subentry) => {
+          KV[`${fixCapsAndSpacing(entry[0])} ${fixCapsAndSpacing(subentry[0])}`] = String(subentry[1]);
+        });
+      }
     } else {
       KV[fixCapsAndSpacing(entry[0])] = String(entry[1]);
     }
   });
   return KV;
+}
+
+// amount has schema:
+// "amount": [ { denom: 'udym', amount: '6000000' } ]
+function getAmountString(obJ: object) : string {
+  let result = ""
+  Object.entries(obJ).forEach((subentry) => {
+    result = subentry[1]["amount"] + " " + subentry[1]["denom"].substring(1)
+  });
+  return result;
 }
 
 export function txStringToHash(txstr: string) {

--- a/packages/service-manager/utils/cosmos.ts
+++ b/packages/service-manager/utils/cosmos.ts
@@ -55,9 +55,16 @@ function convertToKeyValue(obj: { [key: string]: any }): { [key: string]: string
 // amount has schema:
 // "amount": [ { denom: 'udym', amount: '6000000' } ]
 function getAmountString(obJ: object) : string {
-  let result = ""
-  result = obJ[0]["amount"] + " " + obJ[0]["denom"].substring(1)
-  return result;
+  let denom, amount
+  if("udym" === obJ[0]["denom"]) {
+    // special case for dymension 
+    denom = obJ[0]["denom"].substring(1)
+    amount = (Number(obJ[0]["amount"]) / 1000000).toString()
+  } else {
+    denom = obJ[0]["denom"].substring(1)
+    amount = obJ[0]["amount"]
+  }
+  return amount + " " + denom
 }
 
 export function txStringToHash(txstr: string) {

--- a/packages/service-manager/utils/cosmos.ts
+++ b/packages/service-manager/utils/cosmos.ts
@@ -56,9 +56,7 @@ function convertToKeyValue(obj: { [key: string]: any }): { [key: string]: string
 // "amount": [ { denom: 'udym', amount: '6000000' } ]
 function getAmountString(obJ: object) : string {
   let result = ""
-  Object.entries(obJ).forEach((subentry) => {
-    result = subentry[1]["amount"] + " " + subentry[1]["denom"].substring(1)
-  });
+  result = obJ[0]["amount"] + " " + obJ[0]["denom"].substring(1)
   return result;
 }
 

--- a/packages/service-manager/utils/cosmos.ts
+++ b/packages/service-manager/utils/cosmos.ts
@@ -54,7 +54,7 @@ function convertToKeyValue(obj: { [key: string]: any }): { [key: string]: string
 
 // amount has schema:
 // "amount": [ { denom: 'udym', amount: '6000000' } ]
-function getAmountString(obJ: object) : string {
+function getAmountString(obJ: any) : string {
   let denom, amount
   if("udym" === obJ[0]["denom"]) {
     // special case for dymension 


### PR DESCRIPTION
This solution assumes the amount array always contains single element. For example:

`"amount" : [ { denom: 'udym', amount: '6000000' } ]`



Tested with hub tx D3749E28AA0FC7843B1F21267DEBCA36816838E4A9724D8883D7D5E5E624DA7B



before:
![Screen Shot 2023-02-23 at 4 35 44 PM](https://user-images.githubusercontent.com/112976086/221073340-e8593ee5-6ebf-482f-be29-ed7d480defbb.png)




after:
![Screen Shot 2023-02-23 at 4 32 59 PM](https://user-images.githubusercontent.com/112976086/221063018-b415ba57-0272-48e7-8d17-9d3ec90c4bc6.png)

