### PR TITLE
Chain id in block information

### DIFF
--- a/apps/web/lib/service-manager.ts
+++ b/apps/web/lib/service-manager.ts
@@ -138,11 +138,14 @@ async function getBlockBy(queryType: "hash" | "height", queryValue: string, netw
       uniqueIdentifier: blockResponse.result.block_id.hash,
       uniqueIdentifierLabel: "Hash",
       metadata: blockResponse.result.block.data.square_size ? {
+        "Chain Id": blockResponse.result.block.header.chain_id,
         Height: blockResponse.result.block.header.height,
         Time: blockResponse.result.block.header.time,
         "Square Size": blockResponse.result.block.data.square_size,
         Proposer: blockResponse.result.block.header.proposer_address,
+
       } : {
+        "Chain Id": blockResponse.result.block.header.chain_id,
         Height: blockResponse.result.block.header.height,
         Time: blockResponse.result.block.header.time,
         Proposer: blockResponse.result.block.header.proposer_address,

--- a/apps/web/lib/service-manager.ts
+++ b/apps/web/lib/service-manager.ts
@@ -143,7 +143,6 @@ async function getBlockBy(queryType: "hash" | "height", queryValue: string, netw
         Time: blockResponse.result.block.header.time,
         "Square Size": blockResponse.result.block.data.square_size,
         Proposer: blockResponse.result.block.header.proposer_address,
-
       } : {
         "Chain Id": blockResponse.result.block.header.chain_id,
         Height: blockResponse.result.block.header.height,


### PR DESCRIPTION
## Changes
This change dis chain id in block information.

## Notes
Displaying chain id in tx and address page are a little bit tricky as tx api doesn't return chain id in the response. We can tackle them later.
