### PR TITLE
Add logic for fetching EVM & SVM logs

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -18,7 +18,8 @@
         "DYMENSION_HUB_RPC",
         "DYMENSION_ROLLAPP_X_RPC",
         "ADD_NETWORK_PASS",
-        "ADD_NETWORK_ENDPOINT"
+        "ADD_NETWORK_ENDPOINT",
+        "SOLANA_RPC"
       ]
     }
   }


### PR DESCRIPTION
## Currently the UI displays "There are no transactions" when trying to go to:

`http://localhost:3000/solana/transaction/hash/usdrQqxAGgWsBRzzcckAi9ZAzHp19rFCNn87p4Q8Eir`

or 

`http://localhost:3000/Ethereum/Transaction/hash/0xa79b9224f9780fa59d441b54d65988c55d883072f483c3aa6e4d69eabf683cf2`

This PR resolves this issue by allowing data to these endpoints.

## Helpful Screenshots / Info:

Currently using `meta.preOwned` and displaying following info under SVM logs, there are logs under meta.transaction as well but they're strings so unsure if we can make Entity(s) out of it. 

![image](https://user-images.githubusercontent.com/126537323/221772470-a0088b74-17bb-461d-9a52-2fce4b5644dc.png)
