### PR TITLE
Table styling and alignment

### DIFF
--- a/apps/web/ui/entity/table/index.tsx
+++ b/apps/web/ui/entity/table/index.tsx
@@ -1,20 +1,13 @@
 "use client";
 import * as React from "react";
-import { Value as ValueElement } from "./table-cell";
+import { Value } from "./table-cell";
 import { cn } from "~/ui/shadcn/utils";
 
-import type { Value, Page, Column } from "@modularcloud/headless";
-import { capitalize } from "~/lib/shared-utils";
-import { generateColumnStyle } from "~/ui/associated/list/table/column-styles";
+import type { Collection, Column } from "@modularcloud/headless";
 
 interface Props {
-  columns: Column[];
-  entries: Array<{
-    link?: string;
-    row: Record<string, Value>;
-    key: string;
-    card: Record<string, Value>;
-  }>;
+  columns: Collection["tableColumns"];
+  entries: Collection["entries"];
 }
 
 const generateClassname = (breakpoint: Column["breakpoint"]) => {
@@ -47,37 +40,20 @@ const generateClassname = (breakpoint: Column["breakpoint"]) => {
 };
 
 export function Table({ columns, entries }: Props) {
-  const firstEntry = entries[0];
-
-  if (!firstEntry) {
-    return null;
-  }
-
-  let totalLongValues = 0;
-  for (const value of Object.values(firstEntry.row)) {
-    if (value.type === "longval") {
-      totalLongValues++;
-    }
-  }
-
-  let totalHiddenColumns = 0;
-  for (const col of columns) {
-    if (col.hideColumnLabel) {
-      totalHiddenColumns++;
-    }
-  }
-
   return (
     <table className="w-full overflow-y-auto max-w-full">
       <thead className="sticky top-0 bg-white z-10">
         <tr className="h-12 text-left hidden sm:table-row">
+          <th className="px-1 sm:px-3 shadow-[0rem_0.03125rem_0rem_#ECEFF3]" aria-hidden={true}>
+            {/* For spacing purposes only */}
+          </th>
           {columns.map((col) => (
             <th
               key={col.columnLabel}
               className={cn(
                 // bottom border disapears when scrolling, so using a shadow instead
                 "shadow-[0rem_0.03125rem_0rem_#ECEFF3]",
-                "px-4 md:px-8",
+                "px-2",
                 // breakpoints
                 generateClassname(col.breakpoint),
               )}
@@ -87,36 +63,47 @@ export function Table({ columns, entries }: Props) {
               </span>
             </th>
           ))}
+          <th className="px-1 sm:px-3 shadow-[0rem_0.03125rem_0rem_#ECEFF3]" aria-hidden={true}>
+            {/* For spacing purposes only */}
+          </th>
         </tr>
         <tr className="h-12 text-left table-row sm:hidden">
-            <th
-              colSpan={columns.length}
-              className={cn(
-                // bottom border disapears when scrolling, so using a shadow instead
-                "shadow-[0rem_0.03125rem_0rem_#ECEFF3]",
-                "px-4 md:px-8",
-                // breakpoints
-                //generateClassname(col.breakpoint),
-              )}
-            >
-              Transactions
-            </th>
+          <th className="px-1 sm:px-3 shadow-[0rem_0.03125rem_0rem_#ECEFF3]" aria-hidden={true}>
+            {/* For spacing purposes only */}
+          </th>
+
+          <th
+            colSpan={columns.length}
+            className={cn(
+              // bottom border disapears when scrolling, so using a shadow instead
+              "shadow-[0rem_0.03125rem_0rem_#ECEFF3]",
+              "px-2",
+            )}
+          >
+            Transactions
+          </th>
+          <th className="px-1 sm:px-3 shadow-[0rem_0.03125rem_0rem_#ECEFF3]" aria-hidden={true}>
+            {/* For spacing purposes only */}
+          </th>
         </tr>
       </thead>
       <tbody>
         {entries.map((entry) => (
           <tr key={entry.key} className="h-16 border-b border-[#ECEFF3]">
+            <td className="px-1 sm:px-3" aria-hidden={true}>
+              {/* For spacing purposes only */}
+            </td>
             {columns.map((col) => (
               <td
                 key={col.columnLabel}
-                className={cn(
-                  "px-4 md:px-8",
-                  generateClassname(col.breakpoint),
-                )}
+                className={cn("px-2", generateClassname(col.breakpoint))}
               >
-                <ValueElement {...entry.row[col.columnLabel]} />
+                <Value {...entry.row[col.columnLabel]} />
               </td>
             ))}
+            <td className="px-1 sm:px-3" aria-hidden={true}>
+              {/* For spacing purposes only */}
+            </td>
           </tr>
         ))}
       </tbody>

--- a/apps/web/ui/entity/table/index.tsx
+++ b/apps/web/ui/entity/table/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 import * as React from "react";
-import { TableCell } from "./table-cell";
+import { Value as ValueElement } from "./table-cell";
 import { cn } from "~/ui/shadcn/utils";
 
 import type { Value, Page, Column } from "@modularcloud/headless";
@@ -70,7 +70,7 @@ export function Table({ columns, entries }: Props) {
   return (
     <table className="w-full overflow-y-auto max-w-full">
       <thead className="sticky top-0 bg-white z-10">
-        <tr className="h-12 text-left padded-row">
+        <tr className="h-12 text-left hidden sm:table-row">
           {columns.map((col) => (
             <th
               key={col.columnLabel}
@@ -88,6 +88,20 @@ export function Table({ columns, entries }: Props) {
             </th>
           ))}
         </tr>
+        <tr className="h-12 text-left table-row sm:hidden">
+            <th
+              colSpan={columns.length}
+              className={cn(
+                // bottom border disapears when scrolling, so using a shadow instead
+                "shadow-[0rem_0.03125rem_0rem_#ECEFF3]",
+                "px-4 md:px-8",
+                // breakpoints
+                //generateClassname(col.breakpoint),
+              )}
+            >
+              Transactions
+            </th>
+        </tr>
       </thead>
       <tbody>
         {entries.map((entry) => (
@@ -100,7 +114,7 @@ export function Table({ columns, entries }: Props) {
                   generateClassname(col.breakpoint),
                 )}
               >
-                <TableCell value={entry.row[col.columnLabel]} />
+                <ValueElement {...entry.row[col.columnLabel]} />
               </td>
             ))}
           </tr>

--- a/apps/web/ui/entity/table/index.tsx
+++ b/apps/web/ui/entity/table/index.tsx
@@ -12,9 +12,39 @@ interface Props {
   entries: Array<{
     link?: string;
     row: Record<string, Value>;
+    key: string;
     card: Record<string, Value>;
   }>;
 }
+
+const generateClassname = (breakpoint: Column.breakpoint) => {
+  switch (breakpoint) {
+    case "xs":
+      return "max-xs:hidden";
+    case "sm":
+      return "max-sm:hidden";
+    case "md":
+      return "max-md:hidden";
+    case "lg":
+      return "max-lg:hidden";
+    case "xl":
+      return "max-xl:hidden";
+    case "2xl":
+      return "max-2xl:hidden";
+    case "max-xs":
+      return "xs:hidden";
+    case "max-sm":
+      return "sm:hidden";
+    case "max-md":
+      return "md:hidden";
+    case "max-lg":
+      return "lg:hidden";
+    case "max-xl":
+      return "xl:hidden";
+    case "max-2xl":
+      return "2xl:hidden";
+  }
+};
 
 export function Table({ columns, entries }: Props) {
   const firstEntry = entries[0];
@@ -39,66 +69,42 @@ export function Table({ columns, entries }: Props) {
 
   return (
     <table className="w-full overflow-y-auto max-w-full">
-      <thead className="sticky top-0 filter backdrop-blur-sm">
-        <tr
-          className={cn(
-            "flex items-center justify-between border-b border-mid-dark-100",
-            "py-4 px-10 grid",
-          )}
-          style={{
-            gridTemplateColumns: `repeat(${
-              columns.length + totalLongValues - totalHiddenColumns
-            }, minmax(0, 1fr))`,
-            gridAutoColumns: "1fr",
-          }}
-        >
-          {columns
-            .filter((col) => !col.hideColumnLabel)
-            .map((col) => (
-              <th
-                key={col.columnLabel}
-                className={cn(
-                  "font-medium text-start",
-                  firstEntry.row[col.columnLabel].type === "longval" &&
-                    "col-span-2",
-                  col.breakpoint && generateColumnStyle(col),
-                )}
-              >
-                {capitalize(col.columnLabel)}
-              </th>
-            ))}
+      <thead className="sticky top-0 bg-white z-10">
+        <tr className="h-12 text-left padded-row">
+          {columns.map((col) => (
+            <th
+              key={col.columnLabel}
+              className={cn(
+                // bottom border disapears when scrolling, so using a shadow instead
+                "shadow-[0rem_0.03125rem_0rem_#ECEFF3]",
+                "px-4 md:px-8",
+                // breakpoints
+                generateClassname(col.breakpoint),
+              )}
+            >
+              <span className={cn(col.hideColumnLabel && "invisible")}>
+                {col.columnLabel}
+              </span>
+            </th>
+          ))}
         </tr>
       </thead>
-
-      <tbody className="h-full w-full max-w-full overflow-x-clip">
-        {entries.map((entry, index) => {
-          const selectedProperties = columns.map(
-            (col) => [col, entry.row[col.columnLabel]] as const,
-          );
-
-          return (
-            <tr
-              key={index}
-              className={cn(
-                "py-4 px-10 gap-4 w-full max-w-full",
-                "grid border-b border-mid-dark-100",
-              )}
-              style={{
-                gridTemplateColumns: `repeat(${
-                  columns.length + totalLongValues
-                }, minmax(0, 1fr))`,
-              }}
-            >
-              {selectedProperties.map(([column, value], index) => (
-                <TableCell
-                  value={value}
-                  key={column.columnLabel}
-                  className={column.breakpoint && generateColumnStyle(column)}
-                />
-              ))}
-            </tr>
-          );
-        })}
+      <tbody>
+        {entries.map((entry) => (
+          <tr key={entry.key} className="h-16 border-b border-[#ECEFF3]">
+            {columns.map((col) => (
+              <td
+                key={col.columnLabel}
+                className={cn(
+                  "px-4 md:px-8",
+                  generateClassname(col.breakpoint),
+                )}
+              >
+                <TableCell value={entry.row[col.columnLabel]} />
+              </td>
+            ))}
+          </tr>
+        ))}
       </tbody>
     </table>
   );

--- a/apps/web/ui/entity/table/index.tsx
+++ b/apps/web/ui/entity/table/index.tsx
@@ -4,10 +4,57 @@ import { Value } from "./table-cell";
 import { cn } from "~/ui/shadcn/utils";
 
 import type { Collection, Column } from "@modularcloud/headless";
+import { useRouter } from "next/navigation";
 
 interface Props {
   columns: Collection["tableColumns"];
   entries: Collection["entries"];
+}
+
+// I am breaking this into its own component so I can easily prefetch the data
+function TableRow({
+  columns,
+  entry,
+}: {
+  columns: Collection["tableColumns"];
+  entry: Collection["entries"][0];
+}) {
+  const route = useRouter();
+
+  React.useEffect(() => {
+    if (entry.link) {
+      route.prefetch(entry.link);
+    }
+  }, [entry]);
+  return (
+    <tr
+      onClick={(e) => {
+        if (entry.link) {
+          e.stopPropagation();
+          route.push(entry.link);
+        }
+      }}
+      className={cn(
+        "h-16 border-b border-[#ECEFF3]",
+        entry.link && "cursor-pointer",
+      )}
+    >
+      <td className="px-1 sm:px-3" aria-hidden={true}>
+        {/* For spacing purposes only */}
+      </td>
+      {columns.map((col) => (
+        <td
+          key={col.columnLabel}
+          className={cn("px-2", generateClassname(col.breakpoint))}
+        >
+          <Value {...entry.row[col.columnLabel]} />
+        </td>
+      ))}
+      <td className="px-1 sm:px-3" aria-hidden={true}>
+        {/* For spacing purposes only */}
+      </td>
+    </tr>
+  );
 }
 
 const generateClassname = (breakpoint: Column["breakpoint"]) => {
@@ -44,7 +91,10 @@ export function Table({ columns, entries }: Props) {
     <table className="w-full overflow-y-auto max-w-full">
       <thead className="sticky top-0 bg-white z-10">
         <tr className="h-12 text-left hidden sm:table-row">
-          <th className="px-1 sm:px-3 shadow-[0rem_0.03125rem_0rem_#ECEFF3]" aria-hidden={true}>
+          <th
+            className="px-1 sm:px-3 shadow-[0rem_0.03125rem_0rem_#ECEFF3]"
+            aria-hidden={true}
+          >
             {/* For spacing purposes only */}
           </th>
           {columns.map((col) => (
@@ -63,12 +113,18 @@ export function Table({ columns, entries }: Props) {
               </span>
             </th>
           ))}
-          <th className="px-1 sm:px-3 shadow-[0rem_0.03125rem_0rem_#ECEFF3]" aria-hidden={true}>
+          <th
+            className="px-1 sm:px-3 shadow-[0rem_0.03125rem_0rem_#ECEFF3]"
+            aria-hidden={true}
+          >
             {/* For spacing purposes only */}
           </th>
         </tr>
         <tr className="h-12 text-left table-row sm:hidden">
-          <th className="px-1 sm:px-3 shadow-[0rem_0.03125rem_0rem_#ECEFF3]" aria-hidden={true}>
+          <th
+            className="px-1 sm:px-3 shadow-[0rem_0.03125rem_0rem_#ECEFF3]"
+            aria-hidden={true}
+          >
             {/* For spacing purposes only */}
           </th>
 
@@ -82,29 +138,17 @@ export function Table({ columns, entries }: Props) {
           >
             Transactions
           </th>
-          <th className="px-1 sm:px-3 shadow-[0rem_0.03125rem_0rem_#ECEFF3]" aria-hidden={true}>
+          <th
+            className="px-1 sm:px-3 shadow-[0rem_0.03125rem_0rem_#ECEFF3]"
+            aria-hidden={true}
+          >
             {/* For spacing purposes only */}
           </th>
         </tr>
       </thead>
       <tbody>
         {entries.map((entry) => (
-          <tr key={entry.key} className="h-16 border-b border-[#ECEFF3]">
-            <td className="px-1 sm:px-3" aria-hidden={true}>
-              {/* For spacing purposes only */}
-            </td>
-            {columns.map((col) => (
-              <td
-                key={col.columnLabel}
-                className={cn("px-2", generateClassname(col.breakpoint))}
-              >
-                <Value {...entry.row[col.columnLabel]} />
-              </td>
-            ))}
-            <td className="px-1 sm:px-3" aria-hidden={true}>
-              {/* For spacing purposes only */}
-            </td>
-          </tr>
+          <TableRow key={entry.key} columns={columns} entry={entry} />
         ))}
       </tbody>
     </table>

--- a/apps/web/ui/entity/table/index.tsx
+++ b/apps/web/ui/entity/table/index.tsx
@@ -17,7 +17,7 @@ interface Props {
   }>;
 }
 
-const generateClassname = (breakpoint: Column.breakpoint) => {
+const generateClassname = (breakpoint: Column["breakpoint"]) => {
   switch (breakpoint) {
     case "xs":
       return "max-xs:hidden";

--- a/apps/web/ui/entity/table/table-cell.tsx
+++ b/apps/web/ui/entity/table/table-cell.tsx
@@ -17,7 +17,7 @@ export function TableCell({ value, className }: Props) {
   switch (value.type) {
     case "icon":
       return (
-        <td className={cn("flex items-center px-4", className)}>
+        <span className={cn("flex items-center px-4", className)}>
           {value.payload === "SUCCESS" ? (
             <>
               <CheckCircle
@@ -33,21 +33,21 @@ export function TableCell({ value, className }: Props) {
               />
             </>
           )}
-        </td>
+        </span>
       );
     case "longval":
       return (
-        <td className={cn("items-center flex col-span-2 py-4", className)}>
+        <span className={cn("items-center flex col-span-2 py-4", className)}>
           {LongVal({
             max: value.payload.maxLength ?? 25,
             step: value.payload.stepDown ?? 1,
             ...value.payload,
           })}
-        </td>
+        </span>
       );
     case "standard":
       return (
-        <td
+        <span
           className={cn(
             "flex items-center",
             "text-ellipsis whitespace-nowrap overflow-x-hidden flex-shrink flex-grow-0 max-w-full",
@@ -55,13 +55,13 @@ export function TableCell({ value, className }: Props) {
           )}
         >
           {value.payload.toString()}
-        </td>
+        </span>
       );
     case "status":
       return (
-        <td className="flex items-center">
+        <span className="flex items-center">
           <Status status={value.payload} />
-        </td>
+        </span>
       );
     default:
       return null;

--- a/apps/web/ui/entity/table/table-cell.tsx
+++ b/apps/web/ui/entity/table/table-cell.tsx
@@ -30,8 +30,8 @@ export function Value({ payload, type }: Value) {
     case "longval":
       return (
           LongVal({
-            max: payload.maxLength ?? 25,
-            step: payload.stepDown ?? 1,
+            max: payload.maxLength ?? 60,
+            step: payload.stepDown ?? 10,
             ...payload,
           })
       );

--- a/apps/web/ui/entity/table/table-cell.tsx
+++ b/apps/web/ui/entity/table/table-cell.tsx
@@ -6,63 +6,45 @@ import { cn } from "~/ui/shadcn/utils";
 import { LongVal } from "~/ui/long-val";
 import { CheckCircle, XCircle } from "~/ui/icons";
 
-interface Props {
-  value: Value;
-  className?: string;
-}
 
-export function TableCell({ value, className }: Props) {
-  if (value.payload === undefined || value.payload === null) return null;
-
-  switch (value.type) {
+export function Value({ payload, type }: Value) {
+  switch (type) {
     case "icon":
       return (
-        <span className={cn("flex items-center px-4", className)}>
-          {value.payload === "SUCCESS" ? (
+          payload === "SUCCESS" ? (
             <>
               <CheckCircle
-                className="h-5 w-5 flex-shrink-0 text-teal-500 relative top-0.5"
+                className="text-teal-500"
                 aria-hidden="true"
               />
             </>
           ) : (
             <>
               <XCircle
-                className="h-5 w-5 flex-shrink-0 text-red-500 relative top-0.5"
+                className="text-red-500"
                 aria-hidden="true"
               />
             </>
-          )}
-        </span>
+          )
       );
     case "longval":
       return (
-        <span className={cn("items-center flex col-span-2 py-4", className)}>
-          {LongVal({
-            max: value.payload.maxLength ?? 25,
-            step: value.payload.stepDown ?? 1,
-            ...value.payload,
-          })}
-        </span>
+          LongVal({
+            max: payload.maxLength ?? 25,
+            step: payload.stepDown ?? 1,
+            ...payload,
+          })
       );
     case "standard":
       return (
         <span
-          className={cn(
-            "flex items-center",
-            "text-ellipsis whitespace-nowrap overflow-x-hidden flex-shrink flex-grow-0 max-w-full",
-            className,
-          )}
+          className="text-ellipsis whitespace-nowrap overflow-x-hidden flex-shrink flex-grow-0 max-w-full"
         >
-          {value.payload.toString()}
+          {payload}
         </span>
       );
     case "status":
-      return (
-        <span className="flex items-center">
-          <Status status={value.payload} />
-        </span>
-      );
+      return <Status status={!!payload} />
     default:
       return null;
   }

--- a/packages/@modularcloud/headless/integrations/svm/index.ts
+++ b/packages/@modularcloud/headless/integrations/svm/index.ts
@@ -225,6 +225,7 @@ const addressTransactionsResolver = createResolver(
             },
             {
               columnLabel: "Status",
+              breakpoint: "sm",
             },
             {
               columnLabel: "Slot",
@@ -755,10 +756,8 @@ const blockTransactionsResolver = createResolver(
           },
           {
             columnLabel: "Status",
-          },
-          {
-            columnLabel: "Slot",
-          },
+            breakpoint: "sm",
+          }
         ],
         entries: block.transactions.map((transaction) => {
           const properties: Record<string, Value> = {
@@ -770,6 +769,8 @@ const blockTransactionsResolver = createResolver(
               type: "longval",
               payload: {
                 value: transaction.transaction.signatures[0],
+                maxLength: 60,
+                stepDown: 10,
               },
             },
             Slot: {

--- a/packages/@modularcloud/headless/schemas/page.ts
+++ b/packages/@modularcloud/headless/schemas/page.ts
@@ -89,6 +89,7 @@ const CollectionSchema = z.object({
     })
     .array(),
 });
+export type Collection = z.infer<typeof CollectionSchema>;
 
 // Schema for entire page
 export const PageSchema = z.object({


### PR DESCRIPTION
This does not include:
- Infinite scroll
- Virtualization
- Live refresh
- Keyboard navigation
- Cards

Example page: `/eclipse-devnet/blocks/11000000/transactions`
But this won't work in the preview environment until the canary is merged into this branch. Until then, this only works locally