### PR TITLE
Fix/search modal options

### DIFF
--- a/apps/web/app/api/search/route.ts
+++ b/apps/web/app/api/search/route.ts
@@ -1,0 +1,72 @@
+import {
+  SearchBuilders,
+  registerResolvers,
+  resolve,
+} from "@modularcloud/headless";
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { loadIntegration } from "~/lib/headless-utils";
+
+const searchSchema = z.object({
+  networkSlug: z.string().min(1),
+  query: z.string().min(1),
+});
+
+export async function GET(req: NextRequest) {
+  const searchParams = req.nextUrl.searchParams;
+  const validationResult = searchSchema.safeParse(
+    Object.fromEntries(searchParams.entries()),
+  );
+
+  if (!validationResult.success) {
+    return NextResponse.json(
+      {
+        errors: validationResult.error.flatten().fieldErrors,
+      },
+      {
+        status: 422,
+      },
+    );
+  }
+
+  const { networkSlug, query } = validationResult.data;
+  const integration = await loadIntegration(networkSlug);
+
+  const queries = SearchBuilders.map(
+    (searchBuilder) => searchBuilder.getPath(query)!,
+  ).filter(Boolean);
+
+  const resolvedPathsPromise = await Promise.all(
+    queries.map((query) =>
+      integration.resolveRoute(query).then((resolution) => {
+        if (resolution?.type === "success") {
+          return query as [string, string];
+        } else {
+          return null;
+        }
+      }),
+    ),
+  );
+
+  const resolvedPaths = resolvedPathsPromise.filter((path) => path !== null);
+
+  // remove duplicates
+  const newPaths = resolvedPaths.reduce(
+    (acc, current) => {
+      const found = acc.find(
+        (item) => item[0] === current![0] && item[1] === current![1],
+      );
+      if (!found) {
+        acc.push(current!);
+      }
+      return acc;
+    },
+    [] as [string, string][],
+  );
+
+  return NextResponse.json({
+    data: newPaths,
+  });
+}
+
+export const runtime = "edge";

--- a/apps/web/lib/cache-keys.ts
+++ b/apps/web/lib/cache-keys.ts
@@ -14,12 +14,7 @@ export const CACHE_KEYS = {
     evmWithPrice: (networkSlug: string) => ["EVM_WITH_PRICE", networkSlug],
   },
   search: {
-    query: (network: string, query: string, types: string[]) => [
-      "SEARCH_QUERY",
-      network,
-      ...types,
-      query,
-    ],
+    query: (network: string, query: string) => ["SEARCH_QUERY", network, query],
   },
   resolvers: {
     route: (route: HeadlessRoute, context?: PaginationContext) => [

--- a/apps/web/lib/headless-utils.ts
+++ b/apps/web/lib/headless-utils.ts
@@ -16,7 +16,7 @@ export type HeadlessRoute = {
   path: string[];
 };
 
-async function loadIntegration(networkSlug: string) {
+export async function loadIntegration(networkSlug: string) {
   const network = await getSingleNetworkCached(networkSlug);
 
   if (!network) {

--- a/apps/web/ui/header/header-search-button.tsx
+++ b/apps/web/ui/header/header-search-button.tsx
@@ -32,7 +32,10 @@ export function HeaderSearchButton({ optionGroups }: Props) {
     return values.find((network) => network.id === params.network) ?? values[0];
   }, [optionGroups, params.network]);
 
-  const entityType = capitalize(params.path[0]);
+  let entityType = capitalize(params.path[0]);
+  if (entityType.endsWith("s")) {
+    entityType = entityType.substring(0, entityType.length - 1);
+  }
   const query = params.path[1];
 
   return (

--- a/apps/web/ui/network-widgets/layouts/svm/use-widget-data.ts
+++ b/apps/web/ui/network-widgets/layouts/svm/use-widget-data.ts
@@ -15,7 +15,13 @@ const THIRTY_SECONDS = 30 * 1000;
 
 export function useLatestBlocks(context: PageContext) {
   return useSWR(
-    "blocks",
+    [
+      "/api/resolve/blocks",
+      {
+        resolverId: "sealevel-latest-blocks-0.0.0",
+        input: context,
+      },
+    ],
     async () => {
       const response = await fetch("/api/resolve", {
         method: "POST",
@@ -41,7 +47,13 @@ export function useLatestBlocks(context: PageContext) {
 
 export function useLatestTransactions(context: PageContext) {
   return useSWR(
-    "transactions",
+    [
+      "/api/resolve/transactions",
+      {
+        resolverId: "sealevel-latest-transactions-0.0.0",
+        input: context,
+      },
+    ],
     async () => {
       const response = await fetch("/api/resolve", {
         method: "POST",

--- a/apps/web/ui/search/integration-action-list-view.tsx
+++ b/apps/web/ui/search/integration-action-list-view.tsx
@@ -11,7 +11,7 @@ interface Props {
   className?: string;
   onNavigate: () => void;
   onChangeChainClicked: () => void;
-  searcheableTypes: string[];
+  searcheableTypes: [string, string][];
 }
 
 type ListItemType = {
@@ -76,7 +76,7 @@ export function IntegrationActionListView({
         ],
       };
 
-      for (const type of searcheableTypes) {
+      for (const [type, query] of searcheableTypes) {
         items["Types"].push({
           id: type,
           icon: () => null,

--- a/apps/web/ui/search/integration-action-list-view.tsx
+++ b/apps/web/ui/search/integration-action-list-view.tsx
@@ -43,7 +43,7 @@ export function IntegrationActionListView({
       );
     }
 
-    for (const type of searcheableTypes) {
+    for (const [type, query] of searcheableTypes) {
       router.prefetch(
         `/${selectedNetwork.id}/${type}/${encodeURIComponent(query)}`,
       );
@@ -77,6 +77,9 @@ export function IntegrationActionListView({
       };
 
       for (const [type, query] of searcheableTypes) {
+        const typeName = type.endsWith("s")
+          ? type.substring(0, type.length - 1)
+          : type;
         items["Types"].push({
           id: type,
           icon: () => null,
@@ -84,7 +87,7 @@ export function IntegrationActionListView({
             <p className="text-muted overflow-x-hidden whitespace-nowrap text-ellipsis w-full">
               Go to&nbsp;
               <strong className="font-medium text-foreground">
-                {capitalize(type)}
+                {capitalize(typeName)}
               </strong>
               &nbsp;
               <span className="break-all">{query}</span>

--- a/apps/web/ui/search/integration-grid-view.tsx
+++ b/apps/web/ui/search/integration-grid-view.tsx
@@ -5,7 +5,6 @@ import { cn } from "~/ui/shadcn/utils";
 import { useMediaQuery } from "~/lib/hooks/use-media-query";
 import { capitalize } from "~/lib/shared-utils";
 import { useItemGrid } from "./use-item-grid";
-import { useFilteredOptionGroup } from "./use-filtered-option-group";
 
 import type { SearchOption, OptionGroups } from "~/lib/shared-utils";
 interface Props {
@@ -16,11 +15,6 @@ interface Props {
   defaultChainBrand?: string;
 }
 
-/**
- *  - the grid view is navigable with up/down/left/right arrows,
- *  - the grid should be navigable with mouse
- *  - the grid should be navigable with tab key (?)
- */
 export function IntegrationGridView({
   filter,
   onSelectOption,
@@ -28,8 +22,6 @@ export function IntegrationGridView({
   className,
   defaultChainBrand,
 }: Props) {
-  const filteredOptionGroup = useFilteredOptionGroup(optionGroups, filter);
-
   const isOneColumn = useMediaQuery("(max-width: 594px)");
   const isTwoColumns = useMediaQuery(
     "(min-width: 595px) and (max-width: 800px)",
@@ -42,7 +34,7 @@ export function IntegrationGridView({
   const { groupedByLines, getOptionId, registerOptionProps } = useItemGrid({
     noOfColumns,
     parentRef: gridRef.current,
-    optionGroups: filteredOptionGroup,
+    optionGroups,
     onSelectOption,
     defaultOptionGroupKey: defaultChainBrand,
     selectFirstItem: !!filter,

--- a/apps/web/ui/search/search-modal.tsx
+++ b/apps/web/ui/search/search-modal.tsx
@@ -16,7 +16,7 @@ import { IntegrationGridView } from "./integration-grid-view";
 import { GlobalHotkeyContext } from "~/ui/global-hotkey-provider";
 
 // utils
-import { isAddress, isHash, isHeight } from "~/lib/search";
+import { useFilteredOptionGroup } from "./use-filtered-option-group";
 import { capitalize } from "~/lib/shared-utils";
 import { cn } from "~/ui/shadcn/utils";
 
@@ -62,15 +62,12 @@ export function SearchModal({
     [setInputValue],
   );
 
-  const isTransactionOrBlockQuery = isHash(inputValue);
-  const isAddressOnlyQuery = isAddress(inputValue);
-  const isBlockOnlyQuery = isHeight(inputValue);
-  const isEntity =
-    isTransactionOrBlockQuery || isAddressOnlyQuery || isBlockOnlyQuery;
+  const filteredOptionGroup = useFilteredOptionGroup(optionGroups, inputValue);
+  const isNetworkQuery = Object.keys(filteredOptionGroup).length > 0;
 
   const currentNetwork = selectedNetwork
     ? selectedNetwork
-    : isEntity
+    : !isNetworkQuery
     ? defaultNetwork.value
     : selectedNetwork;
 
@@ -150,9 +147,9 @@ export function SearchModal({
             </div>
           </DialogHeader>
 
-          {!currentNetwork && !isEntity && (
+          {!currentNetwork && isNetworkQuery && (
             <IntegrationGridView
-              optionGroups={optionGroups}
+              optionGroups={filteredOptionGroup}
               defaultChainBrand={defaultNetwork.value.brandName}
               filter={inputValue}
               onSelectOption={onSelectOption}
@@ -160,7 +157,7 @@ export function SearchModal({
             />
           )}
 
-          {currentNetwork && (
+          {currentNetwork && !isNetworkQuery && (
             <IntegrationActionListView
               query={inputValue}
               searcheableTypes={searcheableTypes ?? []}

--- a/apps/web/ui/search/search-modal.tsx
+++ b/apps/web/ui/search/search-modal.tsx
@@ -74,22 +74,10 @@ export function SearchModal({
     ? defaultNetwork.value
     : selectedNetwork;
 
-  let typesToCheck: string[] = [];
-  if (isTransactionOrBlockQuery) {
-    typesToCheck = ["transaction", "block"];
-  }
-  if (isAddressOnlyQuery) {
-    typesToCheck = ["address"];
-  }
-  if (isBlockOnlyQuery) {
-    typesToCheck = ["block"];
-  }
-
   const { data: searcheableTypes, isLoading } = useSearcheableEntities({
     network: defaultNetwork.value.id,
     query: inputValue,
-    typesToCheck,
-    enabled: typesToCheck.length > 0,
+    enabled: inputValue.length > 0,
   });
 
   return (

--- a/apps/web/ui/search/search-modal.tsx
+++ b/apps/web/ui/search/search-modal.tsx
@@ -63,13 +63,13 @@ export function SearchModal({
   );
 
   const filteredOptionGroup = useFilteredOptionGroup(optionGroups, inputValue);
-  const isNetworkQuery = Object.keys(filteredOptionGroup).length > 0;
+  const isNetworkQuery =
+    !selectedNetwork && Object.keys(filteredOptionGroup).length > 0;
 
-  const currentNetwork = selectedNetwork
-    ? selectedNetwork
-    : !isNetworkQuery
-    ? defaultNetwork.value
-    : selectedNetwork;
+  let currentNetwork = selectedNetwork;
+  if (!selectedNetwork && !isNetworkQuery) {
+    currentNetwork = defaultNetwork.value;
+  }
 
   const { data: searcheableTypes, isLoading } = useSearcheableEntities({
     network: defaultNetwork.value.id,


### PR DESCRIPTION
This PR adds the ability to filter types on the search modal.

This also removes the logic we had for when to start to search for entity types, previously we used regexes but they only worked with EVM formats, so I refactored the logic to instead search for entities when the query does not satisfies a network.

