### PR TITLE
Fix: nexts cannot over 2MB of data

### DIFF
--- a/apps/web/app/(entity)/[network]/@rightpanel/[...path]/page.tsx
+++ b/apps/web/app/(entity)/[network]/@rightpanel/[...path]/page.tsx
@@ -22,7 +22,7 @@ export default async function RightPanelPage({ params }: Props) {
     notFound();
   }
 
-  const { sidebar } = await loadPage(params);
+  const { sidebar } = await loadPage({ route: params });
 
   return <RightPanel network={network} data={sidebar} />;
 }

--- a/apps/web/app/(entity)/[network]/[...path]/page.tsx
+++ b/apps/web/app/(entity)/[network]/[...path]/page.tsx
@@ -15,7 +15,7 @@ export async function generateMetadata({ params }: { params: HeadlessRoute }) {
     };
   }
 
-  const { metadata } = await loadPage(params);
+  const { metadata } = await loadPage({ route: params });
   return {
     title: metadata.title,
     description: metadata.description,
@@ -46,7 +46,8 @@ async function AyncPageContent({ params }: { params: HeadlessRoute }) {
     }
   }
 
-  const page = await loadPage(params);
+  // TODO : skip cache as of now until collection doesn't return
+  const page = await loadPage({ route: params });
 
   if (page.body.type === "notebook") {
     return <Overview properties={page.body.properties} />;

--- a/apps/web/app/api/load-page/route.ts
+++ b/apps/web/app/api/load-page/route.ts
@@ -1,12 +1,36 @@
 import { NextRequest, NextResponse } from "next/server";
-import { loadPage } from "~/lib/headless-utils";
+import { z } from "zod";
+import { HeadlessRouteSchema, loadPage } from "~/lib/headless-utils";
+
+const loadPageSchema = z.object({
+  route: HeadlessRouteSchema,
+  context: z.object({
+    after: z.string().optional(),
+    limit: z.number().optional(),
+  }),
+  skipCache: z.boolean().optional().default(false),
+});
 
 export async function POST(req: NextRequest) {
-  const { route, context } = await req.json();
+  const body = await req.json();
 
-  const result = await loadPage(route, context);
+  const validationResult = loadPageSchema.safeParse(body);
 
+  if (!validationResult.success) {
+    return NextResponse.json(
+      {
+        errors: validationResult.error.flatten().fieldErrors,
+      },
+      {
+        status: 422,
+      },
+    );
+  }
+
+  const result = await loadPage(validationResult.data);
   return NextResponse.json(result);
 }
 
 export const runtime = "edge";
+// don't cache anything by default, unless manually done so
+export const fetchCache = "default-no-store";

--- a/apps/web/lib/headless-utils.ts
+++ b/apps/web/lib/headless-utils.ts
@@ -13,6 +13,9 @@ import { nextCache } from "./server-utils";
 import { CACHE_KEYS } from "./cache-keys";
 import { z } from "zod";
 
+/**
+ * This is reused on the `api/load-page/route.ts` file
+ */
 export const HeadlessRouteSchema = z.object({
   network: z.string(),
   path: z.array(z.string()),

--- a/apps/web/ui/entity/table/index.tsx
+++ b/apps/web/ui/entity/table/index.tsx
@@ -112,7 +112,11 @@ function TableContent({ initialData, route }: Props) {
           headers: {
             "Content-Type": "application/json",
           },
-          body: JSON.stringify({ route, context: { after: pageParam } }),
+          body: JSON.stringify({
+            route,
+            context: { after: pageParam },
+            skipCache: true,
+          }),
         });
         const data = await response.json();
         return data;

--- a/apps/web/ui/network-widgets/layouts/celestia/use-widget-data.ts
+++ b/apps/web/ui/network-widgets/layouts/celestia/use-widget-data.ts
@@ -18,24 +18,20 @@ const widgetDataSchema = z.object({
 const THIRTY_SECONDS = 30 * 1000;
 
 export function useLatestBlocks(network: string) {
+  const loadPageArgs = {
+    route: { network: network, path: ["blocks"] },
+    context: { limit: 5 },
+    skipCache: true,
+  };
   return useSWR<Page>(
-    [
-      "/api/load-page",
-      {
-        route: { network, path: ["blocks"] },
-        context: { limit: 5 },
-      }
-    ],
+    ["/api/load-page", loadPageArgs],
     async () => {
       const response = await fetch("/api/load-page", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({
-          route: { network: network, path: ["blocks"] },
-          context: { limit: 5 },
-        }),
+        body: JSON.stringify(loadPageArgs),
       });
       const data = await response.json();
       return data;
@@ -50,24 +46,20 @@ export function useLatestBlocks(network: string) {
 }
 
 export function useLatestTransactions(network: string) {
+  const loadPageArgs = {
+    route: { network: network, path: ["transactions"] },
+    context: { limit: 5 },
+    skipCache: true,
+  };
   return useSWR<Page>(
-    [
-      "/api/load-page",
-      {
-        route: { network, path: ["transactions"] },
-        context: { limit: 5 },
-      }
-    ],
+    ["/api/load-page", loadPageArgs],
     async () => {
       const response = await fetch("/api/load-page", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({
-          route: { network: network, path: ["transactions"] },
-          context: { limit: 5 },
-        }),
+        body: JSON.stringify(loadPageArgs),
       });
       const data = await response.json();
       return data;

--- a/apps/web/ui/tabs/header-tabs.tsx
+++ b/apps/web/ui/tabs/header-tabs.tsx
@@ -27,7 +27,9 @@ type Tab = {
 };
 
 export async function HeaderTabs({ params }: Props) {
-  const { tabs: resolvedTabs } = await loadPage(params);
+  const { tabs: resolvedTabs } = await loadPage({
+    route: params,
+  });
 
   // TODO: we should use this schema directly without modification
   const tabs: Tab[] = resolvedTabs.map((tab) => {


### PR DESCRIPTION
This adress a fix for a bug where some data are cached but they way too big (like latest blocks/transactions, etc), most of these should not be cached anyway, so I added an argument to `loadPage` for skipping the cache for these cases.

![image](https://github.com/modularcloud/explorer/assets/146040055/1ad048ce-068e-45f0-9999-bc55bae44cd2)
