### PR TITLE
Fix/hotkey scope

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -6,18 +6,31 @@ const config = {
   reactStrictMode: true,
   transpilePackages: ["service-manager"],
   experimental: {
-    logging: {
-      level: "verbose",
-      fullUrl: true,
-    },
     useDeploymentId: true,
   },
+  logging: {
+    fetches: {
+      fullUrl: true,
+    },
+  },
   images: {
-    domains: [
-      "nautchain.xyz",
-      "mc-nft.s3.us-west-2.amazonaws.com",
-      "mc-config.s3.us-west-2.amazonaws.com",
-      "ucarecdn.com",
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "nautchain.xyz",
+      },
+      {
+        protocol: "https",
+        hostname: "mc-nft.s3.us-west-2.amazonaws.com",
+      },
+      {
+        protocol: "https",
+        hostname: "mc-config.s3.us-west-2.amazonaws.com",
+      },
+      {
+        protocol: "https",
+        hostname: "ucarecdn.com",
+      },
     ],
   },
 };

--- a/apps/web/ui/entity/overview/entry.tsx
+++ b/apps/web/ui/entity/overview/entry.tsx
@@ -39,23 +39,30 @@ export function OverviewEntryList({ entries }: Props) {
 
   useHotkeyListener({
     keys: ["c"],
-    listener: async () => {
-      if (!selectedItem) return;
+    listener: () => {
+      if (!selectedItem) return false;
       const { type, payload } = selectedItem.value;
-      if (payload === null || payload === undefined) return;
+      if (payload === null || payload === undefined) return false;
 
       if (type === "standard" || type === "longval") {
         const value =
           type === "standard" ? payload.toString() : payload.value.toString();
-        const copied = await copyValueToClipboard(value);
-
-        if (copied) {
-          toast({
-            title: "Copied",
-            description: `"${truncateHash(value)}" copied to clipboard`,
-          });
-        }
+        copyValueToClipboard(value).then((copied) => {
+          if (copied) {
+            toast({
+              title: "Copied",
+              description: `"${truncateHash(value)}" copied to clipboard`,
+            });
+          } else {
+            toast({
+              title: "Failed to copy",
+              description: `An`,
+            });
+          }
+        });
+        return true;
       }
+      return false;
     },
     modifier: "META",
   });

--- a/apps/web/ui/global-hotkey-provider/index.tsx
+++ b/apps/web/ui/global-hotkey-provider/index.tsx
@@ -53,6 +53,9 @@ export function GlobalHotkeyProvider({
     };
 
     const keyDownListener = (event: KeyboardEvent) => {
+      // Ignore held down keys & don't listen for them if the search modal is open
+      if (event.repeat || isSearchModalOpen) return;
+
       if (event.key === "/" && !isSearchModalOpen) {
         setSearchModalOpen(true);
         event.preventDefault();

--- a/apps/web/ui/global-hotkey-provider/index.tsx
+++ b/apps/web/ui/global-hotkey-provider/index.tsx
@@ -19,6 +19,7 @@ export const GlobalHotkeyContext = React.createContext<GlobalHotkeyContextType>(
   },
 );
 
+// TODO : refactor to use `useHotkeyListener`
 export function GlobalHotkeyProvider({
   children,
   optionGroups,

--- a/apps/web/ui/search/integration-action-list-view.tsx
+++ b/apps/web/ui/search/integration-action-list-view.tsx
@@ -12,6 +12,7 @@ interface Props {
   onNavigate: () => void;
   onChangeChainClicked: () => void;
   searcheableTypes: [string, string][];
+  parentDialogRef: React.RefObject<React.ElementRef<"div">>;
 }
 
 type ListItemType = {
@@ -28,6 +29,7 @@ export function IntegrationActionListView({
   onChangeChainClicked,
   selectedNetwork,
   searcheableTypes,
+  parentDialogRef,
 }: Props) {
   const router = useRouter();
 
@@ -167,6 +169,7 @@ export function IntegrationActionListView({
     optionGroups: items,
     parentRef: listRef,
     onSelectOption: (option) => option.onSelect(),
+    scopeRef: parentDialogRef,
   });
 
   return (

--- a/apps/web/ui/search/integration-grid-view.tsx
+++ b/apps/web/ui/search/integration-grid-view.tsx
@@ -8,19 +8,19 @@ import { useItemGrid } from "~/lib/hooks/use-item-grid";
 
 import type { SearchOption, OptionGroups } from "~/lib/shared-utils";
 interface Props {
-  filter: string;
   className?: string;
   optionGroups: OptionGroups;
   onSelectOption?: (chain: SearchOption) => void;
   defaultChainBrand?: string;
+  parentDialogRef: React.RefObject<React.ElementRef<"div">>;
 }
 
 export function IntegrationGridView({
-  filter,
   onSelectOption,
   optionGroups,
   className,
   defaultChainBrand,
+  parentDialogRef,
 }: Props) {
   const isOneColumn = useMediaQuery("(max-width: 594px)");
   const isTwoColumns = useMediaQuery(
@@ -35,6 +35,7 @@ export function IntegrationGridView({
     noOfColumns,
     parentRef: gridRef,
     optionGroups,
+    scopeRef: parentDialogRef,
     onSelectOption,
     defaultOptionGroupKeyToSortFirst: defaultChainBrand,
   });

--- a/apps/web/ui/search/search-modal.tsx
+++ b/apps/web/ui/search/search-modal.tsx
@@ -77,6 +77,8 @@ export function SearchModal({
     enabled: inputValue.length > 0,
   });
 
+  const dialogRef = React.useRef<React.ElementRef<"div">>(null);
+
   return (
     <Dialog
       open={isDialogOpen}
@@ -92,6 +94,7 @@ export function SearchModal({
     >
       <DialogTrigger asChild>{children}</DialogTrigger>
       <DialogContent
+        ref={dialogRef}
         style={{
           // @ts-expect-error this is a CSS variable
           "--color-primary": brandColor,
@@ -149,9 +152,9 @@ export function SearchModal({
 
           {!currentNetwork && isNetworkQuery && (
             <IntegrationGridView
+              parentDialogRef={dialogRef}
               optionGroups={filteredOptionGroup}
               defaultChainBrand={defaultNetwork.value.brandName}
-              filter={inputValue}
               onSelectOption={onSelectOption}
               className="max-h-[calc(100%-60px)] overflow-y-auto"
             />
@@ -160,6 +163,7 @@ export function SearchModal({
           {currentNetwork && !isNetworkQuery && (
             <IntegrationActionListView
               query={inputValue}
+              parentDialogRef={dialogRef}
               searcheableTypes={searcheableTypes ?? []}
               selectedNetwork={currentNetwork}
               onChangeChainClicked={() => {

--- a/apps/web/ui/search/search-modal.tsx
+++ b/apps/web/ui/search/search-modal.tsx
@@ -95,6 +95,7 @@ export function SearchModal({
       <DialogTrigger asChild>{children}</DialogTrigger>
       <DialogContent
         ref={dialogRef}
+        onCloseAutoFocus={(e) => e.preventDefault()}
         style={{
           // @ts-expect-error this is a CSS variable
           "--color-primary": brandColor,

--- a/apps/web/ui/tabs/header-tabs-hotkey-listener.tsx
+++ b/apps/web/ui/tabs/header-tabs-hotkey-listener.tsx
@@ -24,7 +24,9 @@ export function HeaderTabsHotkeyListener({ tabList }: Props) {
       const selectedTab = tabList[Number(keyPressed) - 1];
       if (selectedTab) {
         router.push(`/${params.network}/${selectedTab}`);
+        return true;
       }
+      return false;
     },
     modifier: "CTRL",
   });


### PR DESCRIPTION
This PR fixes a bug where if you are  `latest blocks` page and then press enter in the modal you could see behind it selects an option in the table.

This is fixed by stopping the propagation of events. 

I also added two security measures : 

- added a scope to `useItemGrid` so that for the modal, it only listen from events fired in the modal
- added a scope to `useItemListNavigation` which defaults to `window` if not specified (this is because this is what we want for the overview and collection pages).

the scope is the element to attach keyboard events to
