### PR TITLE
Fix: table selection jumping around

### DIFF
--- a/apps/web/lib/hooks/use-hotkey-listener.ts
+++ b/apps/web/lib/hooks/use-hotkey-listener.ts
@@ -54,7 +54,6 @@ export function useHotkeyListener({
       ) {
         const consumed = listener(event.key);
 
-        console.log({ consumed });
         if (consumed) {
           event.stopPropagation();
           event.preventDefault();

--- a/apps/web/lib/hooks/use-item-list-navigation.ts
+++ b/apps/web/lib/hooks/use-item-list-navigation.ts
@@ -157,6 +157,8 @@ export function useItemListNavigation<T>({
     }
   }, [selectItem, onSelectItem, items]);
 
+  // Scroll the item into the view if it isn't visible
+  // In the case where the element is visible, it will do nothing.
   const scrollItemIntoView = React.useCallback(() => {
     const { index, item } = selectedItemPositionRef.current;
 

--- a/apps/web/lib/hooks/use-item-list-navigation.ts
+++ b/apps/web/lib/hooks/use-item-list-navigation.ts
@@ -15,10 +15,6 @@ type UseItemListNavigationArgs<T> = {
    */
   scopeRef?: React.RefObject<HTMLElement | null>;
   /**
-   * Wether or not to scroll to the item when we navigate with the up/down arrows
-   */
-  scrollOnSelection?: boolean;
-  /**
    * Callback for when the item is clicked, either with the mouse
    * or with Enter key, This function should also be memoized
    */
@@ -53,7 +49,6 @@ export function useItemListNavigation<T>({
   onSelectItem,
   onClickItem,
   getItemId,
-  scrollOnSelection = true,
   scopeRef,
 }: UseItemListNavigationArgs<T>) {
   const itemRootId = React.useId();
@@ -167,21 +162,18 @@ export function useItemListNavigation<T>({
   const scrollItemIntoView = React.useCallback(() => {
     const { index, item } = selectedItemPositionRef.current;
 
-    if (item && scrollOnSelection) {
+    if (item) {
       const element = document.getElementById(
         getOptionId(index, item),
       ) as HTMLDivElement | null;
 
-      if (element && parentRef?.current) {
-        if (isElementOverflowing(parentRef.current, element)) {
-          element?.scrollIntoView({
-            behavior: "smooth",
-            block: "end",
-          });
-        }
+      if (element) {
+        element?.scrollIntoView({
+          block: "nearest",
+        });
       }
     }
-  }, [parentRef, getOptionId, scrollOnSelection]);
+  }, [getOptionId]);
 
   // Listen for keyboard events
   React.useEffect(() => {
@@ -223,12 +215,6 @@ export function useItemListNavigation<T>({
           break;
       }
 
-      const { item, index } = selectedItemPositionRef.current;
-      if (!eventIgnored && item) {
-        const element = document.getElementById(getOptionId(index, item));
-        element?.focus();
-      }
-
       // we don't want this event to be propagated to the whole page
       // so that element that listen globally (for hotkey for ex.) don't react accordingly,
       if (!eventIgnored) {
@@ -251,10 +237,10 @@ export function useItemListNavigation<T>({
   }, [
     moveSelectionDown,
     moveSelectionUp,
-    scrollItemIntoView,
     onClickItem,
     getOptionId,
     scopeRef,
+    scrollItemIntoView,
   ]);
 
   const isOptionSelected = React.useCallback(
@@ -283,8 +269,6 @@ export function useItemListNavigation<T>({
           if (selectedItemId !== currentItemId) {
             selectItem({ item, index });
 
-            const element = document.getElementById(getOptionId(index, item));
-            element?.focus();
             onSelectItem?.({
               item: item,
               index: index,

--- a/apps/web/ui/entity/overview/entry.tsx
+++ b/apps/web/ui/entity/overview/entry.tsx
@@ -93,7 +93,6 @@ export function OverviewEntryList({ entries }: Props) {
   const { registerItemProps, selectedItem } = useItemListNavigation({
     items: items,
     getItemId,
-    parentRef: listRef,
     onSelectItem,
   });
 

--- a/apps/web/ui/entity/table/index.tsx
+++ b/apps/web/ui/entity/table/index.tsx
@@ -52,11 +52,7 @@ const generateClassname = (breakpoint: Column["breakpoint"]) => {
   }
 };
 
-export function Table(props: Props) {
-  return <TableContent {...props} />;
-}
-
-function TableContent({ initialData, route }: Props) {
+export function Table({ initialData, route }: Props) {
   let containsData = false;
   // @ts-ignore: Property 'entries' does not exist on type
   if (initialData && initialData.body?.entries?.length > 0) {
@@ -133,8 +129,8 @@ function TableContent({ initialData, route }: Props) {
     fetchMoreOnBottomReached(parentRef.current);
   }, [fetchMoreOnBottomReached]);
 
-  const PADDING_END = 160;
-  const ITEM_SIZE = 65;
+  // const PADDING_END = 160;
+  // const ITEM_SIZE = 65;
   // Removed for now as it causes white blank issues.
   // TODO : reintroduce when we implement the new layout
   // const virtualizer = useVirtualizer({
@@ -177,7 +173,6 @@ function TableContent({ initialData, route }: Props) {
     getItemId,
     onSelectItem,
     items: flatData,
-    scrollOnSelection: true,
     parentRef: parentRef,
     onClickItem,
   });
@@ -288,7 +283,6 @@ function TableContent({ initialData, route }: Props) {
                       key={index}
                       columns={columns}
                       entry={entry}
-                      // virtualRow={virtualRow}
                       currentIndex={index}
                       registerOptionProps={registerOptionProps}
                     />
@@ -339,11 +333,18 @@ const TableRow = React.memo(function TableRow({
           router.push(entry.link);
         }
       }}
-      className={cn("group focus:outline-none text-xs", {
-        "cursor-pointer": entry.link,
-        "aria-[selected=true]:bg-muted-100": entry.link,
-        "aria-[selected=true]:bg-muted-50": !entry.link,
-      })}
+      className={cn(
+        "group focus:outline-none text-xs scroll-mt-[65px]",
+        // this is so that at least one item is shown when scrolling down,
+        // the bottom margin is calculated like this :
+        // size of the <header> (106px) + size of one item (65px) + 10px (additionnal margin)
+        "scroll-mb-[calc(106px_+_65px_+_10px)]",
+        {
+          "cursor-pointer": entry.link,
+          "aria-[selected=true]:bg-muted-100": entry.link,
+          "aria-[selected=true]:bg-muted-50": !entry.link,
+        },
+      )}
       style={{
         height: `65px`,
       }}

--- a/apps/web/ui/entity/table/index.tsx
+++ b/apps/web/ui/entity/table/index.tsx
@@ -173,7 +173,6 @@ export function Table({ initialData, route }: Props) {
     getItemId,
     onSelectItem,
     items: flatData,
-    parentRef: parentRef,
     onClickItem,
   });
 

--- a/apps/web/ui/right-panel/index.tsx
+++ b/apps/web/ui/right-panel/index.tsx
@@ -95,7 +95,6 @@ export function RightPanel({ data, network }: Props) {
       <section
         id="header"
         className="border-b px-6 py-5 gap-4 flex items-center w-full flex-shrink"
-        className="border-b px-6 py-5 gap-4 flex items-center w-full flex-shrink"
       >
         {/* <Image src={data.logo} alt="Logo" /> */}
         <Image
@@ -107,7 +106,6 @@ export function RightPanel({ data, network }: Props) {
           className="object-center object-contain flex-shrink-0"
         />
 
-        <h2 className="text-lg font-medium">
         <h2 className="text-lg font-medium">
           {capitalize(network.chainBrand)} {capitalize(network.chainName)}
         </h2>
@@ -122,7 +120,6 @@ export function RightPanel({ data, network }: Props) {
       </section>
       <section
         id="components"
-        className="pt-4 pb-12 px-6 w-full h-full overflow-y-scroll flex flex-col gap-6 relative"
         className="pt-4 pb-12 px-6 w-full h-full overflow-y-scroll flex flex-col gap-6 relative"
       >
         <AssociatedComponentList


### PR DESCRIPTION
This PR fixes #220 

There were many causes : 
- The focus event where triggered whenever an item was selected, wether using the mouse or arrow up/down -> I removed it
- I instead replaced it with calls to `Element.scrollIntoView()` that is called only on arrow up/down to scroll up or down to the element and make it visible
- Also the bug with the mouse jumping around on fast scroll that where only occuring on safari : it is because safari triggers the `mousemove` event when scrolling even when the mouse hasn't moved at all, so to fix it I manually record the last mouse position and check in `onMouseMove` handler if the position has changed 
