### PR TITLE
Fix performances issues on pages inside `/[network]/[...path]`

### DIFF
--- a/apps/web/app/(entity)/[network]/@rightpanel/[...path]/page.tsx
+++ b/apps/web/app/(entity)/[network]/@rightpanel/[...path]/page.tsx
@@ -2,20 +2,21 @@ import { getSingleNetworkCached } from "~/lib/network";
 import { RightPanel, RightPanelSkeleton } from "~/ui/right-panel";
 import { loadPage, HeadlessRoute } from "~/lib/headless-utils";
 import { notFound } from "next/navigation";
-import { parseHeadlessRouteVercelFix } from "~/lib/shared-utils";
+import * as React from "react";
 
 interface Props {
   params: HeadlessRoute;
 }
 
-export default async function RightPanelPage({ params }: Props) {
-  const pathParams = parseHeadlessRouteVercelFix(params);
-  const entityType = pathParams.path[0];
+export default async function RightPanelPage(props: Props) {
+  return (
+    <React.Suspense fallback={<RightPanelSkeleton />}>
+      <RightPanelPageContent {...props} />
+    </React.Suspense>
+  );
+}
 
-  if (entityType === "search") {
-    return <RightPanelSkeleton />;
-  }
-
+async function RightPanelPageContent({ params }: Props) {
   const network = await getSingleNetworkCached(params.network);
   if (!network) {
     notFound();

--- a/apps/web/app/(entity)/[network]/[...path]/page.tsx
+++ b/apps/web/app/(entity)/[network]/[...path]/page.tsx
@@ -5,22 +5,23 @@ import { Table } from "~/ui/entity/table";
 import { parseHeadlessRouteVercelFix } from "~/lib/shared-utils";
 import { notFound, redirect } from "next/navigation";
 
-export async function generateMetadata({ params }: { params: HeadlessRoute }) {
-  const pathParams = parseHeadlessRouteVercelFix(params);
+// TODO : This is a temporary workaround
+// export async function generateMetadata({ params }: { params: HeadlessRoute }) {
+//   const pathParams = parseHeadlessRouteVercelFix(params);
 
-  if (pathParams.path[0] === "search") {
-    const query = pathParams.path[1];
-    return {
-      title: `Searching for ${query}`,
-    };
-  }
+//   if (pathParams.path[0] === "search") {
+//     const query = pathParams.path[1];
+//     return {
+//       title: `Searching for ${query}`,
+//     };
+//   }
 
-  const { metadata } = await loadPage({ route: params });
-  return {
-    title: metadata.title,
-    description: metadata.description,
-  };
-}
+//   const { metadata } = await loadPage({ route: params });
+//   return {
+//     title: metadata.title,
+//     description: metadata.description,
+//   };
+// }
 
 export default function EntityPage({ params }: { params: HeadlessRoute }) {
   const pathParams = parseHeadlessRouteVercelFix(params);


### PR DESCRIPTION
This fixes perf issues on the block page by : 

- Wrapping the rightpanel inside of suspense
- removing the `generateMetadata` as it is blocking, this is temporary and it is better to replace this with a simple static logic