### PR TITLE
Fix/search page not found

### DIFF
--- a/apps/web/app/(entity)/[network]/@rightpanel/[...path]/page.tsx
+++ b/apps/web/app/(entity)/[network]/@rightpanel/[...path]/page.tsx
@@ -3,6 +3,7 @@ import { RightPanel, RightPanelSkeleton } from "~/ui/right-panel";
 import { loadPage, HeadlessRoute } from "~/lib/headless-utils";
 import { notFound } from "next/navigation";
 import * as React from "react";
+import { parseHeadlessRouteVercelFix } from "~/lib/shared-utils";
 
 interface Props {
   params: HeadlessRoute;
@@ -16,7 +17,14 @@ export default async function RightPanelPage(props: Props) {
   );
 }
 
-async function RightPanelPageContent({ params }: Props) {
+async function RightPanelPageContent({ params: _params }: Props) {
+  const params = parseHeadlessRouteVercelFix(_params);
+  const entityType = params.path[0];
+
+  if (entityType === "search") {
+    return <RightPanelSkeleton />;
+  }
+
   const network = await getSingleNetworkCached(params.network);
   if (!network) {
     notFound();

--- a/apps/web/app/(entity)/[network]/[...path]/page.tsx
+++ b/apps/web/app/(entity)/[network]/[...path]/page.tsx
@@ -6,24 +6,6 @@ import { capitalize, parseHeadlessRouteVercelFix } from "~/lib/shared-utils";
 import { notFound, redirect } from "next/navigation";
 import { getSingleNetworkCached } from "~/lib/network";
 
-// TODO : This is a temporary workaround
-// export async function generateMetadata({ params }: { params: HeadlessRoute }) {
-//   const pathParams = parseHeadlessRouteVercelFix(params);
-
-//   if (pathParams.path[0] === "search") {
-//     const query = pathParams.path[1];
-//     return {
-//       title: `Searching for ${query}`,
-//     };
-//   }
-
-//   const { metadata } = await loadPage({ route: params });
-//   return {
-//     title: metadata.title,
-//     description: metadata.description,
-//   };
-// }
-
 export async function generateMetadata({
   params: _params,
 }: {

--- a/apps/web/app/(entity)/[network]/[...path]/page.tsx
+++ b/apps/web/app/(entity)/[network]/[...path]/page.tsx
@@ -24,10 +24,14 @@ import { getSingleNetworkCached } from "~/lib/network";
 //   };
 // }
 
-export async function generateMetadata({ params }: { params: HeadlessRoute }) {
-  const pathParams = parseHeadlessRouteVercelFix(params);
-  if (pathParams.path[0] === "search") {
-    const query = pathParams.path[1];
+export async function generateMetadata({
+  params: _params,
+}: {
+  params: HeadlessRoute;
+}) {
+  const params = parseHeadlessRouteVercelFix(_params);
+  if (params.path[0] === "search") {
+    const query = params.path[1];
     return {
       title: `Searching for ${query}`,
     };
@@ -54,7 +58,7 @@ export async function generateMetadata({ params }: { params: HeadlessRoute }) {
       return str;
     }
     if (str.match(/^(?:[0-9]+\.){3}[0-9]+$/)) {
-      return str.substr(0, 12) + "...";
+      return str.substring(0, 12) + "...";
     }
     return str.slice(0, 6) + "..." + str.slice(-6);
   }

--- a/apps/web/app/(entity)/[network]/layout.tsx
+++ b/apps/web/app/(entity)/[network]/layout.tsx
@@ -20,14 +20,15 @@ export default async function BlockLayout({
   params: Pick<HeadlessRoute, "network">;
 }) {
   const network = await getSingleNetworkCached(params.network);
+
   return (
     <RQTableProvider>
       <main
         className="min-h-screen flex flex-col h-full"
         style={{
           // @ts-expect-error this is a CSS variable
-          "--color-primary": network!.config.primaryColor,
-          "--gradient-primary": network!.config.cssGradient,
+          "--color-primary": network?.config.primaryColor,
+          "--gradient-primary": network?.config.cssGradient,
         }}
       >
         <HideBodyOverflow />


### PR DESCRIPTION
In this PR I fixed the bug on the search page where it would show a 404 error, by simply showing a skeleton for the `@rightpanel` parallel route, because calling `loadPage` would throw a 404. This also fixes the titles that would show on metadata routes by using the `parseHeadlessRouteVercelFix` function that correctly parses the path params on vercel.