### PR TITLE
🩹 fail fetching silently on widget pages

### DIFF
--- a/apps/web/ui/network-widgets/layouts/celestia/celestia-widget-content.tsx
+++ b/apps/web/ui/network-widgets/layouts/celestia/celestia-widget-content.tsx
@@ -39,12 +39,8 @@ export function CelestiaWidgetLayoutContent({
 
   const lastUpdatedTime = useClientOnlyTime(initialUpdatedAt, [data]);
 
-  if (error) {
-    return <CelestiaWidgetSkeleton error={error} />;
-  }
-
   if (!data) {
-    return <CelestiaWidgetSkeleton />;
+    return <CelestiaWidgetSkeleton error={error} />;
   }
 
   const [apiResult, latestBlocks, latestTransactions] = data;

--- a/apps/web/ui/network-widgets/layouts/dymension/dymension-widget-content.tsx
+++ b/apps/web/ui/network-widgets/layouts/dymension/dymension-widget-content.tsx
@@ -26,12 +26,8 @@ export function DymensionWidgetContent({
 
   const lastUpdatedTime = useClientOnlyTime(initialUpdatedAt, [data]);
 
-  if (error) {
-    return <DymensionWidgetSkeleton error={error.toString()} />;
-  }
-
   if (!data) {
-    return <DymensionWidgetSkeleton />;
+    return <DymensionWidgetSkeleton error={error.toString()} />;
   }
 
   return (

--- a/apps/web/ui/network-widgets/layouts/svm/svm-widget-content.tsx
+++ b/apps/web/ui/network-widgets/layouts/svm/svm-widget-content.tsx
@@ -39,18 +39,18 @@ export function SVMWidgetLayoutContent({
 
   const lastUpdatedTime = useClientOnlyTime(initialUpdatedAt, [data]);
 
-  if (error) {
+  if (!data) {
     return (
       <SVMWidgetSkeleton
-        error={{
-          message: error.toString(),
-        }}
+        error={
+          error
+            ? {
+                message: error.toString(),
+              }
+            : undefined
+        }
       />
     );
-  }
-
-  if (!data) {
-    return <SVMWidgetSkeleton />;
   }
 
   const [apiResult, latestBlocks, latestTransactions] = data;


### PR DESCRIPTION
Show stale data when an error occurs on the widget page.

ref : [FE-53](https://linear.app/modularcloud/issue/FE-53/fail-fetching-widgets-silently)