### PR TITLE
fix not found Block/Tx being cached

### DIFF
--- a/apps/web/lib/headless-utils.ts
+++ b/apps/web/lib/headless-utils.ts
@@ -14,7 +14,6 @@ import { nextCache } from "./server-utils";
 import { CACHE_KEYS } from "./cache-keys";
 import { z } from "zod";
 
-
 /**
  * This is reused on the `api/load-page/route.ts` file
  */
@@ -98,6 +97,11 @@ export async function loadIntegration(
             path,
             additionalContext,
           );
+
+          if (response === null || response.type !== "success") {
+            throw new Error("Not found");
+          }
+
           if (!includeTrace && response !== null) {
             const { trace, ...rest } = response;
             return rest;
@@ -145,27 +149,31 @@ export async function loadPage({
 
   const fixedPath = parseHeadlessRouteVercelFix(route).path;
 
-  const resolution = await integration.resolveRoute(fixedPath, context);
+  try {
+    const resolution = await integration.resolveRoute(fixedPath, context);
 
-  if (!resolution) {
+    if (!resolution) {
+      notFound();
+    }
+
+    if (resolution.type === "pending") {
+      /**
+       * Pending responses are for items that cannot be found, but may exist in the future.
+       * For example, if the latest block is 100, and we request block 101, we will get a pending response.
+       * Therefore, in the short-term we will treat this as any other page that is not found.
+       * However, we will have a special treatment for this in the future.
+       */
+      notFound();
+    }
+
+    if (resolution.type === "error") {
+      throw new Error(resolution.error);
+    }
+
+    return resolution.result as Page;
+  } catch (error) {
     notFound();
   }
-
-  if (resolution.type === "pending") {
-    /**
-     * Pending responses are for items that cannot be found, but may exist in the future.
-     * For example, if the latest block is 100, and we request block 101, we will get a pending response.
-     * Therefore, in the short-term we will treat this as any other page that is not found.
-     * However, we will have a special treatment for this in the future.
-     */
-    notFound();
-  }
-
-  if (resolution.type === "error") {
-    throw new Error(resolution.error);
-  }
-
-  return resolution.result as Page;
 }
 
 export async function search(networkSlug: string, query: string) {


### PR DESCRIPTION
This fix is a workaround around the pending data, we explicitely don't cache them by throwing an error, so that next doesn't store their result in the cache.

ref: [FE-51](https://linear.app/modularcloud/issue/FE-51/blocktx-not-found-are-being-cached)