### PR TITLE
Fix: add "end of table" indicator

### DIFF
--- a/apps/web/ui/entity/table/index.tsx
+++ b/apps/web/ui/entity/table/index.tsx
@@ -228,11 +228,11 @@ export function Table({ initialData, route }: Props) {
       {containsData && flatData.length > 0 ? (
         <div ref={parentRef} className="overflow-y-auto h-screen">
           <div
-            className="[&_+_*]:mb-20 [&_+_*]:tab:mb-0 group"
+            className="[&_+_*]:mb-20"
             //  style={{ height: `${virtualizer.getTotalSize()}px` }}
           >
             <table
-              className="w-full max-w-full border-separate bg-muted-100 group-[&:only-child]:mb-48 group-[&:only-child]:tab:mb-0"
+              className="w-full max-w-full border-separate bg-muted-100"
               style={{ borderSpacing: "0 1px" }}
             >
               <thead className="sticky top-0 bg-white z-10 text-sm">
@@ -311,12 +311,18 @@ export function Table({ initialData, route }: Props) {
             </table>
           </div>
 
-          {hasNextPage && (
+          {hasNextPage ? (
             <TableSkeleton
               sectionRef={loadMoreFallbackRef}
               noOfItems={3}
               className="border-none"
             />
+          ) : (
+            <div className="py-5 w-full px-8 flex justify-center items-baseline gap-4 pb-[6.5rem]">
+              <hr className="h-2 w-full max-w-[10rem] flex-1" />
+              <span className="text-sm text-muted">End of the table</span>
+              <hr className="h-2 w-full max-w-[10rem] flex-1" />
+            </div>
           )}
         </div>
       ) : (


### PR DESCRIPTION
This is a small QOL improvement but also a bug fix for table UI : On desktop some items weren't shown and there wasn't an indication to the user that they reached the end of it.  

## Before


https://github.com/modularcloud/explorer/assets/38298743/f122a84d-6801-440b-8761-2572f6246873


## After   


https://github.com/modularcloud/explorer/assets/38298743/5e6e2405-e565-4033-a243-2321e2206c9d

