### PR TITLE
💄 change widget SVG colors to current color

### DIFF
--- a/apps/web/ui/icons/BarChart.tsx
+++ b/apps/web/ui/icons/BarChart.tsx
@@ -9,7 +9,7 @@ const SvgBarChart = (props: SVGProps<SVGSVGElement>) => (
     {...props}
   >
     <path
-      stroke="#8457FF"
+      stroke="currentColor"
       strokeLinecap="square"
       strokeLinejoin="round"
       strokeWidth={2}

--- a/apps/web/ui/icons/Disabled.tsx
+++ b/apps/web/ui/icons/Disabled.tsx
@@ -9,7 +9,7 @@ const SvgDisabled = (props: SVGProps<SVGSVGElement>) => (
     {...props}
   >
     <path
-      stroke="#8457FF"
+      stroke="currentColor"
       strokeLinecap="round"
       strokeWidth={2}
       d="M18.364 5.636A9 9 0 1 0 5.636 18.364M18.364 5.636A9 9 0 1 1 5.636 18.364M18.364 5.636 5.636 18.364"

--- a/apps/web/ui/icons/Document.tsx
+++ b/apps/web/ui/icons/Document.tsx
@@ -9,7 +9,7 @@ const SvgDocument = (props: SVGProps<SVGSVGElement>) => (
     {...props}
   >
     <path
-      stroke="#8457FF"
+      stroke="currentColor"
       strokeLinecap="round"
       strokeWidth={2}
       d="M13 3H6a1 1 0 0 0-1 1v16a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V9m-6-6 6 6m-6-6v5a1 1 0 0 0 1 1h5M9 13h3m-3 4h6.5"

--- a/apps/web/ui/icons/Folder.tsx
+++ b/apps/web/ui/icons/Folder.tsx
@@ -9,7 +9,7 @@ const SvgFolder = (props: SVGProps<SVGSVGElement>) => (
     {...props}
   >
     <path
-      stroke="#8457FF"
+      stroke="currentColor"
       strokeLinecap="round"
       strokeLinejoin="round"
       strokeWidth={2}


### PR DESCRIPTION
The icons colors were hardcoded to a default value, and I just replaced it to take the primary color of the current network.

ref: [FE-71](https://linear.app/modularcloud/issue/FE-71/eclipse-icons-are-purple)