### PR TITLE
🚸 select first item by default in action-list to allow for `Enter` to work

### DIFF
--- a/apps/web/ui/search/integration-action-list-view.tsx
+++ b/apps/web/ui/search/integration-action-list-view.tsx
@@ -194,9 +194,11 @@ export const IntegrationActionListView = React.memo(
         : actionItems;
     }, [actionItems, ecosystemNetworks]);
 
-    const { registerOptionProps, groupedByLines: groupedItems } = useItemGrid<
-      ListItemType | NetworkChain
-    >({
+    const {
+      registerOptionProps,
+      groupedByLines: groupedItems,
+      selectOption,
+    } = useItemGrid<ListItemType | NetworkChain>({
       noOfColumns: 1,
       optionGroups: gridItems,
       onClickOption: (option) => {
@@ -267,6 +269,14 @@ export const IntegrationActionListView = React.memo(
         registerOptionProps(rowIndex, 0, option),
       [registerOptionProps],
     );
+
+    React.useEffect(() => {
+      selectOption({
+        rowIndex: 0,
+        colIndex: 0,
+        option: gridItems[0][0],
+      });
+    }, [selectOption, gridItems]);
 
     return (
       <div


### PR DESCRIPTION


ref: [FE-78](https://linear.app/modularcloud/issue/FE-78/enter-does-not-work-for-search-in-modal)