### PR TITLE
🐛 fix bug with metadata OG pointing to preview url

### DIFF
--- a/apps/web/app/(home)/[network]/page.tsx
+++ b/apps/web/app/(home)/[network]/page.tsx
@@ -10,7 +10,6 @@ import type { HeadlessRoute } from "~/lib/headless-utils";
 import { SVMWidgetLayout } from "~/ui/network-widgets/layouts/svm";
 import { CelestiaWidgetLayout } from "~/ui/network-widgets/layouts/celestia";
 import { DymensionWidgetLayout } from "~/ui/network-widgets/layouts/dymension";
-import { DEFAULT_URL } from "~/app/api/og/utils";
 
 interface Props {
   params: Pick<HeadlessRoute, "network">;
@@ -24,7 +23,7 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
     title: `${capitalize(network.brand)}`,
     description: `A block explorer for the ${network.brand} ecosystem.`,
     openGraph: {
-      url: DEFAULT_URL + `/${network.slug}`,
+      url: `/${network.slug}`,
       type: "website",
       images: [`/api/og?model=network-home&networkSlug=${network.slug}`],
     },

--- a/apps/web/app/(home)/[network]/page.tsx
+++ b/apps/web/app/(home)/[network]/page.tsx
@@ -23,7 +23,9 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
 
   return {
     title: `${capitalize(network.brand)}`,
-    description: `A block explorer for the ${network.brand} ecosystem.`,
+    description: `A block explorer for the ${capitalize(
+      network.brand,
+    )} ecosystem.`,
     openGraph: {
       url: `/${network.slug}`,
       type: "website",

--- a/apps/web/app/(home)/[network]/page.tsx
+++ b/apps/web/app/(home)/[network]/page.tsx
@@ -25,7 +25,7 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
     openGraph: {
       url: `/${network.slug}`,
       type: "website",
-      images: [`/api/og?model=network-home&networkSlug=${network.slug}`],
+      images: `/api/og?model=network-home&networkSlug=${network.slug}`,
     },
   };
 }

--- a/apps/web/app/(home)/[network]/page.tsx
+++ b/apps/web/app/(home)/[network]/page.tsx
@@ -10,6 +10,8 @@ import type { HeadlessRoute } from "~/lib/headless-utils";
 import { SVMWidgetLayout } from "~/ui/network-widgets/layouts/svm";
 import { CelestiaWidgetLayout } from "~/ui/network-widgets/layouts/celestia";
 import { DymensionWidgetLayout } from "~/ui/network-widgets/layouts/dymension";
+import { env } from "~/env.mjs";
+import { OG_SIZE } from "~/lib/constants";
 
 interface Props {
   params: Pick<HeadlessRoute, "network">;
@@ -25,7 +27,12 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
     openGraph: {
       url: `/${network.slug}`,
       type: "website",
-      images: `/api/og?model=network-home&networkSlug=${network.slug}`,
+      images: [
+        {
+          url: `${env.NEXT_PUBLIC_PRODUCTION_URL}/api/og?model=network-home&networkSlug=${network.slug}`,
+          ...OG_SIZE,
+        },
+      ],
     },
   };
 }

--- a/apps/web/app/api/og/components/opengraph-home.tsx
+++ b/apps/web/app/api/og/components/opengraph-home.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @next/next/no-img-element */
-import { SIZE } from "~/app/api/og/utils";
+import { OG_SIZE } from "~/lib/constants";
 import { getSingleNetworkCached } from "~/lib/network";
 
 export type OpenGraphHomeProps = {
@@ -16,7 +16,7 @@ export async function OpenGraphHome({ networkSlug }: OpenGraphHomeProps) {
     <div
       style={{
         background: "linear-gradient(180deg, #0D0D12 0%, #000 100%)",
-        height: `${SIZE.height}px`,
+        height: `${OG_SIZE.height}px`,
       }}
       tw="relative w-full text-white flex flex-col items-center pt-[150px]"
     >

--- a/apps/web/app/api/og/route.tsx
+++ b/apps/web/app/api/og/route.tsx
@@ -1,7 +1,7 @@
 import { ImageResponse } from "next/og";
 import { NextRequest } from "next/server";
 import { z } from "zod";
-import { SIZE } from "./utils";
+import { OG_SIZE } from "~/lib/constants";
 import { OpenGraphHome } from "./components/opengraph-home";
 
 const ogSearchParamsSchema = z.union([
@@ -40,7 +40,7 @@ export async function GET(req: NextRequest) {
   return new ImageResponse(
     <>{await OpenGraphHome({ networkSlug: params.networkSlug })}</>,
     {
-      ...SIZE,
+      ...OG_SIZE,
       fonts: [
         {
           name: "Geist",

--- a/apps/web/app/api/og/utils.ts
+++ b/apps/web/app/api/og/utils.ts
@@ -1,10 +1,4 @@
-import { env } from "~/env.mjs";
-
 export const SIZE = {
   width: 1600,
   height: 900,
 };
-
-export const DEFAULT_URL = env.VERCEL_URL
-  ? env.VERCEL_URL
-  : "http://localhost:3000";

--- a/apps/web/app/api/og/utils.ts
+++ b/apps/web/app/api/og/utils.ts
@@ -1,4 +1,0 @@
-export const SIZE = {
-  width: 1600,
-  height: 900,
-};

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -6,6 +6,7 @@ import { TailwindIndicator } from "~/ui/tailwind-indicator";
 import { GlobalHotkeyProvider } from "~/ui/global-hotkey-provider";
 import { SkipToMainContent } from "~/ui/skip-to-main-content";
 import { SpeedInsights } from "@vercel/speed-insights/next";
+import { env } from "~/env.mjs";
 
 // utils
 import localFont from "next/font/local";
@@ -48,6 +49,7 @@ export const metadata: Metadata = {
   description: "A block exporer for modular blockchains.",
   keywords:
     "block explorer, modular cloud, modular, blockchain, ethereum, evm, cosmos, ibc, rollapp, rollups, namespace, data availability, celestia, eclipse, nautilus, dymension, caldera, worlds, aeg, aether games",
+  metadataBase: new URL(env.NEXT_PUBLIC_PRODUCTION_URL),
 };
 
 export default async function RootLayout({

--- a/apps/web/env.mjs
+++ b/apps/web/env.mjs
@@ -30,6 +30,7 @@ export const env = createEnv({
     }, z.string().url().optional()),
   },
   client: {
+    NEXT_PUBLIC_PRODUCTION_URL: z.string().url().optional().default("https://explorer.modular.cloud"),
     NEXT_PUBLIC_ADOBE_EMBED_API_KEY: z.string(),
     NEXT_PUBLIC_SVM_METRICS: z.string().url(),
     // add scheme to VERCEL_URL
@@ -39,6 +40,7 @@ export const env = createEnv({
     }, z.string().url().optional()),
   },
   runtimeEnv: {
+    NEXT_PUBLIC_PRODUCTION_URL: process.env.NEXT_PUBLIC_PRODUCTION_URL,
     REVALIDATE_TOKEN: process.env.REVALIDATE_TOKEN,
     INTERNAL_INTEGRATION_API_URL: process.env.INTERNAL_INTEGRATION_API_URL,
     METRICS_API_URL: process.env.METRICS_API_URL,

--- a/apps/web/lib/constants.ts
+++ b/apps/web/lib/constants.ts
@@ -19,3 +19,8 @@ export const DYMENSION_ROLLAPP_IBC_RESOLVER_INPUT = {
 } as const;
 export const DYMENSION_LOGO_URL =
   "https://mc-config.s3.us-west-2.amazonaws.com/dymension-froopyland.png";
+
+export const OG_SIZE = {
+  width: 1600,
+  height: 900,
+};

--- a/turbo.json
+++ b/turbo.json
@@ -49,7 +49,8 @@
         "SVM_DEVNET_RPC_ALTERNATIVE",
         "CELESTIA_MAINNET_BACKUP_NODE",
         "NEXT_PUBLIC_ADOBE_EMBED_API_KEY",
-        "BLOB_READ_WRITE_TOKEN"
+        "BLOB_READ_WRITE_TOKEN",
+        "NEXT_PUBLIC_PRODUCTION_URL"
       ]
     },
     "verify#build": {


### PR DESCRIPTION
I fixed it by adding a new variable `NEXT_PUBLIC_PRODUCTION_URL` that must be set in each env like so :
- canary : `canary.modular.cloud`
- production : `explorer.modular.cloud`