### PR TITLE
🏷️ fix React variables CSS types

### DIFF
--- a/apps/web/app/(entity)/[network]/layout.tsx
+++ b/apps/web/app/(entity)/[network]/layout.tsx
@@ -26,7 +26,6 @@ export default async function BlockLayout({
       <main
         className="min-h-screen flex flex-col h-full"
         style={{
-          // @ts-expect-error this is a CSS variable
           "--color-primary": network?.config.primaryColor,
           "--gradient-primary": network?.config.cssGradient,
         }}

--- a/apps/web/app/(entity)/[network]/not-found.tsx
+++ b/apps/web/app/(entity)/[network]/not-found.tsx
@@ -10,7 +10,6 @@ export default function NotFound() {
     <main
       id="main-content"
       style={{
-        // @ts-expect-error this is a CSS variable
         "--color-primary": DEFAULT_BRAND_COLOR,
       }}
       className="flex w-full flex-col h-lvh items-center justify-center gap-6 text-center"

--- a/apps/web/app/(home)/@logo/[network]/page.tsx
+++ b/apps/web/app/(home)/@logo/[network]/page.tsx
@@ -16,7 +16,6 @@ export default async function NetworkLogo(props: Props) {
     <div
       className="flex flex-col gap-8 items-center pt-44"
       style={{
-        // @ts-expect-error this is a CSS variable
         "--color-primary": network.config.primaryColor,
       }}
     >

--- a/apps/web/app/(home)/@logo/_page.tsx
+++ b/apps/web/app/(home)/@logo/_page.tsx
@@ -7,7 +7,6 @@ export default function HomeLogo() {
     <div
       className="flex flex-col gap-8 items-center pt-44"
       style={{
-        // @ts-expect-error this is a CSS variable
         "--color-primary": DEFAULT_BRAND_COLOR,
       }}
     >

--- a/apps/web/app/(register)/register/page.tsx
+++ b/apps/web/app/(register)/register/page.tsx
@@ -15,7 +15,6 @@ export default function RegisterPage() {
       id="main-content"
       className="h-[100dvh] flex flex-col items-stretch"
       style={{
-        // @ts-expect-error this is a CSS variable
         "--color-primary": "212 100% 49%",
       }}
     >

--- a/apps/web/app/global-error.tsx
+++ b/apps/web/app/global-error.tsx
@@ -15,7 +15,6 @@ export default function GlobalError() {
         <main
           className="flex h-screen w-full flex-col items-center justify-center gap-6 text-center"
           style={{
-            // @ts-expect-error this is a CSS variable
             "--color-primary": DEFAULT_BRAND_COLOR,
           }}
         >

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -12,7 +12,6 @@ export default function NotFound() {
     <main
       id="main-content"
       style={{
-        // @ts-expect-error this is a CSS variable
         "--color-primary": DEFAULT_BRAND_COLOR,
       }}
       className="flex w-full flex-col h-lvh items-center justify-center gap-6 text-center"

--- a/apps/web/global.d.ts
+++ b/apps/web/global.d.ts
@@ -1,0 +1,7 @@
+import * as React from "react";
+
+declare module "react" {
+  interface CSSProperties {
+    [key: `--${string}`]: string | number | undefined | null;
+  }
+}

--- a/apps/web/lib/network.ts
+++ b/apps/web/lib/network.ts
@@ -79,7 +79,7 @@ export async function getAllNetworks(): Promise<Array<SingleNetwork>> {
         nextToken = result?.nextToken;
 
         if (result?.integrations) {
-          // @ts-expect-error
+          // @ts-expect-error non null integrations are filtered out
           allIntegrations = [
             ...allIntegrations,
             ...result.integrations.filter(Boolean),

--- a/apps/web/ui/header-tabs/header-tabs-filter-button.tsx
+++ b/apps/web/ui/header-tabs/header-tabs-filter-button.tsx
@@ -92,7 +92,6 @@ export function HeaderTabsFilterButton({
         side="bottom"
         align="end"
         style={{
-          // @ts-expect-error
           "--color-primary": primaryColor,
         }}
         className="bg-white w-56 flex flex-col gap-1 p-1 rounded-xl"
@@ -130,7 +129,6 @@ export function HeaderTabsFilterButton({
               align="end"
               className="bg-white p-0 rounded-md w-min"
               style={{
-                // @ts-expect-error
                 "--color-primary": primaryColor,
               }}
             >

--- a/apps/web/ui/header/header-search-button.tsx
+++ b/apps/web/ui/header/header-search-button.tsx
@@ -62,7 +62,6 @@ export function HeaderSearchButton({ optionGroups }: Props) {
         )}
         variant="bordered"
         style={{
-          // @ts-expect-error this is a CSS variable
           "--color-primary": network.brandColor,
         }}
       >

--- a/apps/web/ui/network-widgets/layouts/celestia/celestia-widget-content.tsx
+++ b/apps/web/ui/network-widgets/layouts/celestia/celestia-widget-content.tsx
@@ -66,7 +66,6 @@ export function CelestiaWidgetLayoutContent({
 
       <div
         style={{
-          // @ts-expect-error this is a CSS variable
           "--color-primary": networkBrandColor,
         }}
         className={cn(

--- a/apps/web/ui/network-widgets/layouts/celestia/index.tsx
+++ b/apps/web/ui/network-widgets/layouts/celestia/index.tsx
@@ -38,7 +38,6 @@ export async function CelestiaWidgetLayout({
          * We define them as variables here because we use the same layout in the skeleton,
          * For more infos about how to use grid-template-areas see here :https://developer.mozilla.org/fr/docs/Web/CSS/grid-template-areas
          */
-        // @ts-expect-error this is a CSS variable
         "--grid-area-mobile": `
             "LT LT"
             "LT LT"

--- a/apps/web/ui/network-widgets/layouts/svm/index.tsx
+++ b/apps/web/ui/network-widgets/layouts/svm/index.tsx
@@ -38,7 +38,6 @@ export async function SVMWidgetLayout({
          * We define them as variables here because we use the same layout in the skeleton,
          * For more infos about how to use grid-template-areas see here :https://developer.mozilla.org/fr/docs/Web/CSS/grid-template-areas
          */
-        // @ts-expect-error this is a CSS variable
         "--grid-area-mobile": `
             "LT LT"
             "LT LT"

--- a/apps/web/ui/network-widgets/layouts/svm/svm-widget-content.tsx
+++ b/apps/web/ui/network-widgets/layouts/svm/svm-widget-content.tsx
@@ -86,7 +86,6 @@ export function SVMWidgetLayoutContent({
       </div>
       <div
         style={{
-          // @ts-expect-error this is a CSS variable
           "--color-primary": networkBrandColor,
         }}
         className={cn(

--- a/apps/web/ui/search/integration-grid-view.tsx
+++ b/apps/web/ui/search/integration-grid-view.tsx
@@ -147,7 +147,11 @@ type BrandChainsProps = {
 
 function formatEcosystemName(ecosystem: string) {
   const nameParts = ecosystem.split("-").filter(Boolean);
-  return nameParts.map((str, i) => i === nameParts.length - 1 ? `(${capitalize(str)})` : capitalize(str)).join(" ");
+  return nameParts
+    .map((str, i) =>
+      i === nameParts.length - 1 ? `(${capitalize(str)})` : capitalize(str),
+    )
+    .join(" ");
 }
 
 const BrandChains = React.memo(function BrandChains({
@@ -213,7 +217,6 @@ const BrandChains = React.memo(function BrandChains({
           role="presentation"
           id={`row-${rowIndex}-col-${colIndex}-header`}
           style={{
-            // @ts-expect-error This is a CSS variable
             "--color-primary": options[0].brandColor.replaceAll(",", ""),
           }}
         >
@@ -242,9 +245,7 @@ const BrandChains = React.memo(function BrandChains({
                     }}
                   >
                     <Tooltip
-                      label={`${formatEcosystemName(
-                        ecosystem.id,
-                      )} Ecosystem`}
+                      label={`${formatEcosystemName(ecosystem.id)} Ecosystem`}
                     >
                       <Image
                         src={ecosystem.logoURL}

--- a/apps/web/ui/search/search-form.tsx
+++ b/apps/web/ui/search/search-form.tsx
@@ -44,7 +44,6 @@ export function SearchForm({ optionGroups }: Props) {
   return (
     <div
       style={{
-        // @ts-expect-error this is a CSS variable
         "--color-primary": primaryColor,
       }}
       className={cn(

--- a/apps/web/ui/search/search-modal.tsx
+++ b/apps/web/ui/search/search-modal.tsx
@@ -149,7 +149,6 @@ export function SearchModal({
         ref={dialogRef}
         onCloseAutoFocus={(e) => e.preventDefault()}
         style={{
-          // @ts-expect-error this is a CSS variable
           "--color-primary": brandColor,
         }}
         className={cn(

--- a/apps/web/ui/skip-to-main-content/index.tsx
+++ b/apps/web/ui/skip-to-main-content/index.tsx
@@ -6,7 +6,6 @@ export function SkipToMainContent() {
   return (
     <a
       style={{
-        // @ts-expect-error this is a CSS variable
         "--color-primary": DEFAULT_BRAND_COLOR,
       }}
       className={cn(


### PR DESCRIPTION
This is for something that was annoying for some time already, React CSS `style` prop doesn't support css variables by default, previously i fixed it by adding `@ts-expect-error` comments everywhere, but it ignores some errors and that allowed some runtime errors to appear that could have been catched by TS. 

So to fix it I overloaded the CSS `style` prop type to support css variables.