### PR TITLE
Refactor/resolve data on search page

### DIFF
--- a/apps/web/app/(entity)/[network]/@rightpanel/[...path]/page.tsx
+++ b/apps/web/app/(entity)/[network]/@rightpanel/[...path]/page.tsx
@@ -40,7 +40,7 @@ async function RightPanelPageContent({ params: _params }: Props) {
     }
 
     if (searchResult.status === "fulfilled" && searchResult.value) {
-      return <RightPanelSkeleton />;
+      return (params.path = searchResult.value);
     }
 
     return null;

--- a/apps/web/app/(entity)/[network]/[...path]/layout.tsx
+++ b/apps/web/app/(entity)/[network]/[...path]/layout.tsx
@@ -20,18 +20,13 @@ interface Props {
 
 export default function EntityLayout({ children, params }: Props) {
   const pathParams = parseHeadlessRouteVercelFix(params);
-  const entityType = pathParams.path[0];
 
   return (
     <>
-      {entityType === "search" ? (
-        <HeaderTabsSkeleton />
-      ) : (
-        <React.Suspense fallback={<HeaderTabsSkeleton />}>
-          <HeaderTabs params={params} />
-          <HeaderTabsMobile params={params} />
-        </React.Suspense>
-      )}
+      <React.Suspense fallback={<HeaderTabsSkeleton />}>
+        <HeaderTabs params={pathParams} />
+        <HeaderTabsMobile params={pathParams} />
+      </React.Suspense>
       <section
         className={cn(
           "overflow-x-clip fixed left-0 bottom-0 lg:max-w-[calc(100%_-_27rem)] w-full",

--- a/apps/web/app/(entity)/[network]/[...path]/page.tsx
+++ b/apps/web/app/(entity)/[network]/[...path]/page.tsx
@@ -8,49 +8,13 @@ import {
   UnhealthyNetworkError,
 } from "~/lib/headless-utils";
 import { Table } from "~/ui/entity/table";
-import { capitalize, parseHeadlessRouteVercelFix } from "~/lib/shared-utils";
+import { getMetadata, parseHeadlessRouteVercelFix } from "~/lib/shared-utils";
 import { notFound } from "next/navigation";
 import { getSingleNetworkCached } from "~/lib/network";
 import { displayFiltersSchema } from "~/lib/display-filters";
 import { ALWAYS_ONLINE_NETWORKS } from "~/lib/constants";
 import { ShallowPush } from "~/ui/shallow-push";
-
-function shortenId(str: string) {
-  if (str.length < 12) {
-    return str;
-  }
-  if (str.match(/^(?:[0-9]+\.){3}[0-9]+$/)) {
-    return str.substring(0, 12) + "...";
-  }
-  return str.slice(0, 6) + "..." + str.slice(-6);
-}
-
-function formatTypeName(str: string, singular?: boolean) {
-  const pluralToSingular: Record<string, string> = {
-    addresses: "address",
-  };
-
-  const formatMap: Record<string, string> = {
-    eth: "ETH",
-    spl: "SPL",
-  };
-  const parts = str.split("-");
-
-  return parts
-    .map((part, index) => {
-      if (singular && index === parts.length - 1) {
-        let mappedSingular = pluralToSingular[part.toLowerCase()];
-        if (mappedSingular) {
-          return capitalize(mappedSingular);
-        }
-        if (part.endsWith("s")) {
-          return capitalize(str.slice(0, -1));
-        }
-      }
-      return formatMap[part.toLowerCase()] || capitalize(part);
-    })
-    .join(" ");
-}
+import { SearchMetadata } from "~/ui/search-metadata";
 
 export async function generateMetadata({
   params: _params,
@@ -58,56 +22,20 @@ export async function generateMetadata({
   params: HeadlessRoute;
 }) {
   const params = parseHeadlessRouteVercelFix(_params);
+
+  const network = await getSingleNetworkCached(params.network);
+  if (!network) {
+    return {};
+  }
+
   if (params.path[0] === "search") {
     const query = params.path[1];
     return {
       title: `Searching for ${query}`,
     };
   }
-  const network = await getSingleNetworkCached(params.network);
-  if (!network) {
-    return {};
-  }
 
-  // Special cases
-  if (
-    params.path.length === 1 &&
-    (params.path[0] === "transactions" || params.path[0] === "blocks")
-  ) {
-    return {
-      title: `Latest ${capitalize(params.path[0])} on ${capitalize(
-        network.brand,
-      )} ${capitalize(network.chainName)}`,
-      description: `Latest ${capitalize(params.path[0])} on ${capitalize(
-        network.brand,
-      )} ${capitalize(network.chainName)}, brought to you by Modular Cloud.`,
-    };
-  }
-
-  let titleParts = [];
-  let descriptionParts = [];
-  for (let i = 0; i < params.path.length; i += 2) {
-    const type = params.path[i];
-    const id = params.path[i + 1];
-
-    if (!id) {
-      titleParts.unshift(formatTypeName(type));
-      descriptionParts.unshift(formatTypeName(type));
-      break;
-    }
-
-    titleParts.unshift(`${formatTypeName(type, true)} ${shortenId(id)}`);
-    descriptionParts.unshift(`${formatTypeName(type, true)} ${id}`);
-  }
-
-  return {
-    title: `${titleParts.join(" - ")} - ${capitalize(
-      network.brand,
-    )} ${capitalize(network.chainName)}`,
-    description: `${descriptionParts.join(" in ")} on ${capitalize(
-      network.brand,
-    )} ${capitalize(network.chainName)}, brought to you by Modular Cloud.`,
-  };
+  return getMetadata(params, network);
 }
 
 export default function EntityPage({
@@ -133,23 +61,21 @@ async function AyncPageContent({
   params: HeadlessRoute;
   searchParams?: Record<string, any>;
 }) {
+  const network = await getSingleNetworkCached(params.network);
+  if (!network) {
+    notFound();
+  }
+
   const entityType = params.path[0];
 
   let redirectTo: string | null = null;
 
   if (entityType === "search") {
     const query = params.path[1];
-    const [networkResult, searchResult, networkStatusResult] =
-      await Promise.allSettled([
-        getSingleNetworkCached(params.network),
-        search(params.network, query),
-        checkIfNetworkIsOnline(params.network),
-      ]);
-
-    const network = networkResult.status === "fulfilled" && networkResult.value;
-    if (!network) {
-      notFound();
-    }
+    const [searchResult, networkStatusResult] = await Promise.allSettled([
+      search(params.network, query),
+      checkIfNetworkIsOnline(params.network),
+    ]);
 
     if (
       !ALWAYS_ONLINE_NETWORKS.includes(network.brand) &&
@@ -173,7 +99,19 @@ async function AyncPageContent({
   if (page.body.type === "notebook") {
     return (
       <>
-        {redirectTo && <ShallowPush path={redirectTo} />}
+        {redirectTo && (
+          <>
+            <ShallowPush path={redirectTo} />
+            <SearchMetadata
+              correctPath={redirectTo}
+              network={{
+                brand: network.brand,
+                chainName: network.chainName,
+                slug: network.slug,
+              }}
+            />
+          </>
+        )}
         <Overview properties={page.body.properties} isIBC={page.isIBC} />
       </>
     );
@@ -181,7 +119,19 @@ async function AyncPageContent({
 
   return (
     <>
-      {redirectTo && <ShallowPush path={redirectTo} />}
+      {redirectTo && (
+        <>
+          <ShallowPush path={redirectTo} />
+          <SearchMetadata
+            correctPath={redirectTo}
+            network={{
+              brand: network.brand,
+              chainName: network.chainName,
+              slug: network.slug,
+            }}
+          />
+        </>
+      )}
       <Table initialData={page} route={params} />
     </>
   );

--- a/apps/web/lib/network.ts
+++ b/apps/web/lib/network.ts
@@ -168,23 +168,6 @@ export async function getSingleNetworkCached(slug: string) {
 
 export async function getAllPaidNetworks() {
   // `getAllNetworksCached` doesn't work during `next build`, so we manually call `getAllNetworks()`
-  const allNetworks = await (env.NEXT_PUBLIC_VERCEL_URL
-    ? getAllNetworksCached()
-    : getAllNetworks());
+  const allNetworks = await getAllNetworksCached();
   return allNetworks.filter((network) => network.paidVersion).slice(0, 30);
-}
-
-export async function getNetworksForPlatform(platform: string) {
-  const allNetworks = await (env.NEXT_PUBLIC_VERCEL_URL
-    ? getAllNetworksCached()
-    : getAllNetworks());
-
-  return allNetworks.filter((network) => network.config.platform === platform);
-}
-export async function getNetworksForPlatformCached(platform: string) {
-  const getNetworksForPlatformFn = nextCache(getNetworksForPlatform, {
-    tags: CACHE_KEYS.networks.platform(platform),
-  });
-
-  return await getNetworksForPlatformFn(platform);
 }

--- a/apps/web/lib/shared-utils.ts
+++ b/apps/web/lib/shared-utils.ts
@@ -194,3 +194,97 @@ export function arrayGroupByTo2DArray<T extends Record<string, any>>(
 
   return Array.from(map.values());
 }
+
+function shortenId(str: string) {
+  if (str.length < 12) {
+    return str;
+  }
+  if (str.match(/^(?:[0-9]+\.){3}[0-9]+$/)) {
+    return str.substring(0, 12) + "...";
+  }
+  return str.slice(0, 6) + "..." + str.slice(-6);
+}
+
+function formatTypeName(str: string, singular?: boolean) {
+  const pluralToSingular: Record<string, string> = {
+    addresses: "address",
+  };
+
+  const formatMap: Record<string, string> = {
+    eth: "ETH",
+    spl: "SPL",
+  };
+  const parts = str.split("-");
+
+  return parts
+    .map((part, index) => {
+      if (singular && index === parts.length - 1) {
+        let mappedSingular = pluralToSingular[part.toLowerCase()];
+        if (mappedSingular) {
+          return capitalize(mappedSingular);
+        }
+        if (part.endsWith("s")) {
+          return capitalize(str.slice(0, -1));
+        }
+      }
+      return formatMap[part.toLowerCase()] || capitalize(part);
+    })
+    .join(" ");
+}
+
+export function getMetadata(
+  routeParams: HeadlessRoute,
+  network: {
+    brand: string;
+    chainName: string;
+  },
+) {
+  const params = parseHeadlessRouteVercelFix(routeParams);
+
+  if (params.path[0] === "search") {
+    const query = params.path[1];
+    return {
+      title: `Searching for ${query}`,
+    };
+  }
+
+  // Special cases
+  if (
+    params.path.length === 1 &&
+    (params.path[0] === "transactions" || params.path[0] === "blocks")
+  ) {
+    return {
+      title: `Latest ${capitalize(params.path[0])} on ${capitalize(
+        network.brand,
+      )} ${capitalize(network.chainName)}`,
+      description: `Latest ${capitalize(params.path[0])} on ${capitalize(
+        network.brand,
+      )} ${capitalize(network.chainName)}, brought to you by Modular Cloud.`,
+    };
+  }
+
+  let titleParts = [];
+  let descriptionParts = [];
+  for (let i = 0; i < params.path.length; i += 2) {
+    const type = params.path[i];
+    const id = params.path[i + 1];
+
+    if (!id) {
+      titleParts.unshift(formatTypeName(type));
+      descriptionParts.unshift(formatTypeName(type));
+      break;
+    }
+
+    titleParts.unshift(`${formatTypeName(type, true)} ${shortenId(id)}`);
+    descriptionParts.unshift(`${formatTypeName(type, true)} ${id}`);
+  }
+
+  return {
+    title: `${titleParts.join(" - ")} - ${capitalize(
+      network.brand,
+    )} ${capitalize(network.chainName)}`,
+    description: `${descriptionParts.join(" in ")} on ${capitalize(
+      network.brand,
+    )} ${capitalize(network.chainName)}, brought to you by Modular Cloud.`,
+  };
+}

--- a/apps/web/ui/empty/index.tsx
+++ b/apps/web/ui/empty/index.tsx
@@ -3,7 +3,7 @@ interface Props {
   description: String;
 }
 
-export function NotFound({ heading, description }: Props) {
+export function Empty({ heading, description }: Props) {
   return (
     <div className="flex h-[80vh] w-full flex-col items-center justify-center gap-y-3 text-center">
       <svg
@@ -20,15 +20,15 @@ export function NotFound({ heading, description }: Props) {
         <path
           d="M24 40H36C38.2091 40 40 38.2091 40 36V24H8M24 40H12C9.79086 40 8 38.2091 8 36V24M24 40V8H12C9.79086 8 8 9.79086 8 12V24"
           stroke="#DFE1E7"
-          stroke-linecap="round"
-          stroke-linejoin="round"
+          strokeLinecap="round"
+          strokeLinejoin="round"
         />
         <path
           d="M40 4H28V20H44V8C44 5.79086 42.2091 4 40 4Z"
           fill="#FAEDCC"
           stroke="#FFBE4C"
-          stroke-linecap="round"
-          stroke-linejoin="round"
+          strokeLinecap="round"
+          strokeLinejoin="round"
         />
       </svg>
 

--- a/apps/web/ui/entity/table/index.tsx
+++ b/apps/web/ui/entity/table/index.tsx
@@ -12,7 +12,7 @@ import {
   OnSelectItemArgs,
   useItemListNavigation,
 } from "~/lib/hooks/use-item-list-navigation";
-import { NotFound } from "~/ui/not-found";
+import { Empty } from "~/ui/empty";
 import { useSpotlightStore } from "~/ui/right-panel/spotlight-store";
 import { displayFiltersSchema } from "~/lib/display-filters";
 import { range } from "~/lib/shared-utils";
@@ -325,7 +325,7 @@ export function Table({ initialData, route }: Props) {
           )}
         </div>
       ) : (
-        <NotFound
+        <Empty
           heading="Nothing to see here!"
           description="This table is empty"
         />

--- a/apps/web/ui/header/header-search-button.tsx
+++ b/apps/web/ui/header/header-search-button.tsx
@@ -7,13 +7,9 @@ import Image from "next/image";
 import { Button } from "~/ui/button";
 
 // utils
-import { useParams } from "next/navigation";
+import { useParams, usePathname } from "next/navigation";
 import { cn } from "~/ui/shadcn/utils";
-import {
-  capitalize,
-  parseHeadlessRouteVercelFix,
-  truncateHash,
-} from "~/lib/shared-utils";
+import { capitalize, truncateHash } from "~/lib/shared-utils";
 
 // types
 import type { HeadlessRoute } from "~/lib/headless-utils";
@@ -24,8 +20,15 @@ interface Props {
 
 export function HeaderSearchButton({ optionGroups }: Props) {
   const routeParams = useParams() as HeadlessRoute;
+  const pathname = usePathname();
 
-  const params = parseHeadlessRouteVercelFix(routeParams);
+  const params: HeadlessRoute = {
+    ...routeParams,
+    path: pathname
+      .replace(`/${routeParams.network}`, "")
+      .split("/")
+      .filter(Boolean),
+  };
 
   const network = React.useMemo(() => {
     const values = Object.values(optionGroups).flat();

--- a/apps/web/ui/right-panel/index.tsx
+++ b/apps/web/ui/right-panel/index.tsx
@@ -87,7 +87,6 @@ export function RightPanel({ data, network }: Props) {
       <div
         className="w-full grid h-full max-h-full auto-rows-min"
         style={{
-          backgroundImage: "url(/images/grid-layout-vector.svg)",
           backgroundPosition: "bottom center",
           backgroundRepeat: "no-repeat",
           backgroundSize: "contain",
@@ -152,7 +151,6 @@ export function RightPanelSkeleton() {
       <div
         className="w-full grid h-full max-h-full auto-rows-min"
         style={{
-          backgroundImage: "url(/images/grid-layout-vector.svg)",
           backgroundPosition: "bottom center",
           backgroundRepeat: "no-repeat",
           backgroundSize: "contain",

--- a/apps/web/ui/search-metadata/index.tsx
+++ b/apps/web/ui/search-metadata/index.tsx
@@ -1,4 +1,3 @@
-"use client";
 import * as React from "react";
 
 import { getMetadata } from "~/lib/shared-utils";
@@ -26,7 +25,7 @@ export function SearchMetadata({ correctPath, network }: Props) {
 
   return (
     <>
-      <title>{title} - Modular Cloud</title>
+      <title>{`${title} - Modular Cloud`}</title>
       {description && <meta name="description" content={description} />}
     </>
   );

--- a/apps/web/ui/search-metadata/index.tsx
+++ b/apps/web/ui/search-metadata/index.tsx
@@ -1,0 +1,33 @@
+"use client";
+import * as React from "react";
+
+import { getMetadata } from "~/lib/shared-utils";
+
+interface Props {
+  correctPath: string;
+  network: {
+    slug: string;
+    brand: string;
+    chainName: string;
+  };
+}
+
+export function SearchMetadata({ correctPath, network }: Props) {
+  const { title, description } = getMetadata(
+    {
+      network: network.slug,
+      path: correctPath
+        .replace(`/${network.slug}`, "")
+        .split("/")
+        .filter(Boolean),
+    },
+    network,
+  );
+
+  return (
+    <>
+      <title>{title} - Modular Cloud</title>
+      {description && <meta name="description" content={description} />}
+    </>
+  );
+}

--- a/apps/web/ui/shallow-push/index.tsx
+++ b/apps/web/ui/shallow-push/index.tsx
@@ -1,0 +1,17 @@
+"use client";
+import React from "react";
+
+interface Props {
+  path: string;
+}
+
+export function ShallowPush({ path }: Props) {
+  React.useEffect(() => {
+    shallowPush(path);
+  }, [path]);
+  return null;
+}
+
+export function shallowPush(path: string) {
+  window.history.pushState(null, "", path);
+}

--- a/apps/web/ui/shallow-push/index.tsx
+++ b/apps/web/ui/shallow-push/index.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React from "react";
+import * as React from "react";
 
 interface Props {
   path: string;


### PR DESCRIPTION
Refactor the search page to load the data then show it and reroute to the correct route with shallow routing. 

I also had to add some logic for resolving the metadata in that case because it would keep the metatada of the search page.